### PR TITLE
feat: add alarm edit screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import {NavigationContainer} from '@react-navigation/native'
 import {createNativeStackNavigator} from '@react-navigation/native-stack'
 import HomeScreen from './screens/HomeScreen'
 import CreateAlarmScreen from './screens/CreateAlarmScreen'
+import EditAlarmScreen from './screens/EditAlarmScreen'
 
 const Stack = createNativeStackNavigator()
 
@@ -12,6 +13,7 @@ export default function App() {
         <Stack.Navigator>
           <Stack.Screen name="Home" component={HomeScreen} />
           <Stack.Screen name="CreateAlarm" component={CreateAlarmScreen} />
+          <Stack.Screen name="EditAlarm" component={EditAlarmScreen} />
         </Stack.Navigator>
       </NavigationContainer>
   );

--- a/screens/EditAlarmScreen.tsx
+++ b/screens/EditAlarmScreen.tsx
@@ -1,0 +1,93 @@
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native'
+import { useState, useEffect } from 'react'
+import { useNavigation, useRoute } from '@react-navigation/native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Alarm } from '../types/Alarm'
+
+export default function EditAlarmScreen() {
+    const navigation = useNavigation()
+    const route = useRoute()
+    const { id } = route.params as { id: string }
+
+    const [startDate, setStartDate] = useState('')
+    const [interval, setInterval] = useState('')
+    const [name, setName] = useState('')
+
+    useEffect(() => {
+        const load = async () => {
+            const json = await AsyncStorage.getItem('alarms')
+            const alarms: Alarm[] = json ? JSON.parse(json) : []
+            const target = alarms.find((a) => a.id === id)
+            if (target) {
+                setName(target.name)
+                setStartDate(new Date(target.createdAt).toISOString().slice(0, 10))
+                setInterval(String(target.interval))
+            }
+        }
+        load()
+    }, [id])
+
+    const handleSave = async () => {
+        const json = await AsyncStorage.getItem('alarms')
+        const alarms: Alarm[] = json ? JSON.parse(json) : []
+        const updated = alarms.map((alarm) =>
+            alarm.id === id
+                ? {
+                      ...alarm,
+                      interval: parseInt(interval),
+                      createdAt: new Date(startDate).toISOString(),
+                  }
+                : alarm
+        )
+        await AsyncStorage.setItem('alarms', JSON.stringify(updated))
+        navigation.goBack()
+    }
+
+    return (
+        <View style={styles.container}>
+            <Text style={styles.label}>알람 이름</Text>
+            <Text style={styles.name}>{name}</Text>
+
+            <Text style={styles.label}>시작일 (YYYY-MM-DD)</Text>
+            <TextInput
+                style={styles.input}
+                value={startDate}
+                onChangeText={setStartDate}
+                placeholder="2024-01-01"
+            />
+
+            <Text style={styles.label}>주기 (일)</Text>
+            <TextInput
+                style={styles.input}
+                value={interval}
+                onChangeText={setInterval}
+                keyboardType="numeric"
+            />
+
+            <Button title="저장" onPress={handleSave} />
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        padding: 24,
+        backgroundColor: '#fff',
+    },
+    label: {
+        fontSize: 16,
+        marginTop: 16,
+    },
+    input: {
+        borderWidth: 1,
+        borderColor: '#ccc',
+        padding: 12,
+        borderRadius: 8,
+        marginTop: 8,
+    },
+    name: {
+        fontSize: 18,
+        marginTop: 8,
+    },
+})

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -41,7 +41,7 @@ export default function HomeScreen() {
         const diffDays = Math.floor(
             (now.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
         )
-        return Math.min(diffDays / interval, 1)
+        return Math.min(Math.max(diffDays, 0) / interval, 1)
     }
 
     const deleteAlarm = async (id: string) => {
@@ -91,7 +91,7 @@ export default function HomeScreen() {
                             style={{ marginTop: 8 }}
                         />
 
-                        {/* 버튼 2개 나란히 */}
+                        {/* 버튼 3개 나란히 */}
                         <View
                             style={{
                                 flexDirection: 'row',
@@ -100,6 +100,14 @@ export default function HomeScreen() {
                                 marginTop: 8,
                             }}
                         >
+                            <Button
+                                title="✏️ 수정"
+                                onPress={() =>
+                                    navigation.navigate('EditAlarm' as never, {
+                                        id: alarm.id,
+                                    } as never)
+                                }
+                            />
                             <Button
                                 title="🔁 갱신"
                                 onPress={() => updateAlarmDate(alarm.id)}


### PR DESCRIPTION
## Summary
- allow editing alarm start date and period
- wire edit screen into navigation and home actions
- handle negative progress values when computing progress bar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f2eef5b2c832e95cf0f08a3124069