### PR TITLE
fix: generate alarm IDs without uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
         "react-native-progress": "^5.0.1",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
-        "react-native-web": "^0.20.0",
-        "uuid": "^11.1.0"
+        "react-native-web": "^0.20.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -8446,19 +8445,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "react-native-progress": "^5.0.1",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
-    "react-native-web": "^0.20.0",
-    "uuid": "^11.1.0"
+    "react-native-web": "^0.20.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/screens/CreateAlarmScreen.tsx
+++ b/screens/CreateAlarmScreen.tsx
@@ -4,7 +4,14 @@ import { useState } from 'react'
 import { useNavigation } from '@react-navigation/native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Alarm } from '../types/Alarm'
-import { v4 as uuidv4 } from 'uuid'  // uuid 패키지 필요
+
+// 간단한 UUID v4 생성 함수 (Math.random 기반)
+const uuidv4 = () =>
+    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = (Math.random() * 16) | 0
+        const v = c === 'x' ? r : (r & 0x3) | 0x8
+        return v.toString(16)
+    })
 
 export default function CreateAlarmScreen() {
     const navigation = useNavigation()


### PR DESCRIPTION
## Summary
- replace uuid package with custom Math.random-based ID generator to keep alarm creation working on iOS
- remove unused uuid dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit` *(fails: Argument of type '[never, never]' is not assignable to parameter of type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_688f3d6298a8832e9f2ce95fd89c4863