### PR TITLE
Fix navigation types and handle promises

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,11 +1,12 @@
 import {StyleSheet} from 'react-native';
 import {NavigationContainer} from '@react-navigation/native'
 import {createNativeStackNavigator} from '@react-navigation/native-stack'
+import { RootStackParamList } from './types/navigation'
 import HomeScreen from './screens/HomeScreen'
 import CreateAlarmScreen from './screens/CreateAlarmScreen'
 import EditAlarmScreen from './screens/EditAlarmScreen'
 
-const Stack = createNativeStackNavigator()
+const Stack = createNativeStackNavigator<RootStackParamList>()
 
 export default function App() {
   return (

--- a/screens/CreateAlarmScreen.tsx
+++ b/screens/CreateAlarmScreen.tsx
@@ -2,12 +2,16 @@
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native'
 import { useState } from 'react'
 import { useNavigation } from '@react-navigation/native'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Alarm } from '../types/Alarm'
 import { v4 as uuidv4 } from 'uuid'  // uuid 패키지 필요
+import { RootStackParamList } from '../types/navigation'
 
 export default function CreateAlarmScreen() {
-    const navigation = useNavigation()
+    const navigation = useNavigation<
+        NativeStackNavigationProp<RootStackParamList, 'CreateAlarm'>
+    >()
     const [name, setName] = useState('')
     const [interval, setInterval] = useState('')
 

--- a/screens/EditAlarmScreen.tsx
+++ b/screens/EditAlarmScreen.tsx
@@ -1,13 +1,17 @@
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native'
 import { useState, useEffect } from 'react'
-import { useNavigation, useRoute } from '@react-navigation/native'
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Alarm } from '../types/Alarm'
+import { RootStackParamList } from '../types/navigation'
 
 export default function EditAlarmScreen() {
-    const navigation = useNavigation()
-    const route = useRoute()
-    const { id } = route.params as { id: string }
+    const navigation = useNavigation<
+        NativeStackNavigationProp<RootStackParamList, 'EditAlarm'>
+    >()
+    const route = useRoute<RouteProp<RootStackParamList, 'EditAlarm'>>()
+    const { id } = route.params
 
     const [startDate, setStartDate] = useState('')
     const [interval, setInterval] = useState('')
@@ -24,7 +28,7 @@ export default function EditAlarmScreen() {
                 setInterval(String(target.interval))
             }
         }
-        load()
+        void load()
     }, [id])
 
     const handleSave = async () => {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,13 +1,17 @@
 import { View, Text, Button } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Alarm } from '../types/Alarm'
 import { useFocusEffect } from '@react-navigation/native'
 import { useState, useCallback } from 'react'
 import * as Progress from 'react-native-progress'
+import { RootStackParamList } from '../types/navigation'
 
 export default function HomeScreen() {
-    const navigation = useNavigation()
+    const navigation = useNavigation<
+        NativeStackNavigationProp<RootStackParamList, 'Home'>
+    >()
     const [alarms, setAlarms] = useState<Alarm[]>([])
 
     useFocusEffect(
@@ -17,7 +21,7 @@ export default function HomeScreen() {
                 const saved: Alarm[] = json ? JSON.parse(json) : []
                 setAlarms(saved)
             }
-            loadAlarms()
+            void loadAlarms()
         }, [])
     )
 
@@ -103,9 +107,9 @@ export default function HomeScreen() {
                             <Button
                                 title="✏️ 수정"
                                 onPress={() =>
-                                    navigation.navigate('EditAlarm' as never, {
+                                    navigation.navigate('EditAlarm', {
                                         id: alarm.id,
-                                    } as never)
+                                    })
                                 }
                             />
                             <Button
@@ -125,7 +129,7 @@ export default function HomeScreen() {
             <View style={{ marginTop: 24 }}>
                 <Button
                     title="➕ 알람 등록"
-                    onPress={() => navigation.navigate('CreateAlarm' as never)}
+                    onPress={() => navigation.navigate('CreateAlarm')}
                 />
             </View>
         </View>

--- a/types/navigation.ts
+++ b/types/navigation.ts
@@ -1,0 +1,5 @@
+export type RootStackParamList = {
+    Home: undefined
+    CreateAlarm: undefined
+    EditAlarm: { id: string }
+}


### PR DESCRIPTION
## Summary
- define RootStackParamList and use typed navigators/hooks across screens
- call `void loadAlarms()` to avoid unhandled promise warning

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688f412d7d84832eb0613330ece12a18