### PR TITLE
Fix iOS alarm registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
         "react-native-progress": "^5.0.1",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
-        "react-native-web": "^0.20.0",
-        "uuid": "^11.1.0"
+        "react-native-web": "^0.20.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -8446,19 +8445,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "react-native-progress": "^5.0.1",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
-    "react-native-web": "^0.20.0",
-    "uuid": "^11.1.0"
+    "react-native-web": "^0.20.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/screens/CreateAlarmScreen.tsx
+++ b/screens/CreateAlarmScreen.tsx
@@ -5,7 +5,6 @@ import { useNavigation } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { Alarm } from '../types/Alarm'
-import { v4 as uuidv4 } from 'uuid'  // uuid 패키지 필요
 import { RootStackParamList } from '../types/navigation'
 
 export default function CreateAlarmScreen() {
@@ -15,11 +14,14 @@ export default function CreateAlarmScreen() {
     const [name, setName] = useState('')
     const [interval, setInterval] = useState('')
 
+    const createId = () =>
+        Date.now().toString(36) + Math.random().toString(36).slice(2, 10)
+
     const handleSubmit = async () => {
         if (!name || !interval) return
 
         const newAlarm: Alarm = {
-            id: uuidv4(),
+            id: createId(),
             name,
             interval: parseInt(interval),
             createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Replace uuid usage with lightweight timestamp-based ID generator to avoid missing crypto on iOS
- Remove uuid dependency

## Testing
- `npm test` (fails: Missing script)
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688f4558f9e0832eac45ed9c8d0b6a95