### PR TITLE
Refine swipe delete action and list appearance

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -23,6 +23,7 @@ const AlarmList = ({ alarms, deleteAlarm, updateAlarmDate, onEdit }: Props) => (
             />
         )}
         contentContainerStyle={styles.container}
+        showsVerticalScrollIndicator={false}
     />
 )
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -36,23 +36,31 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     )
 
     const renderRightActions = (
-        _progress: Animated.AnimatedInterpolation<number>,
+        progress: Animated.AnimatedInterpolation<number>,
         dragX: Animated.AnimatedInterpolation<number>
     ) => {
         const translateX = dragX.interpolate({
-            inputRange: [-100, 0],
-            outputRange: [0, 80],
+            inputRange: [-88, 0],
+            outputRange: [0, 88],
             extrapolate: 'clamp',
         })
+        const opacity = progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, 1],
+        })
+
         return (
             <Animated.View
-                style={[styles.deleteAction, { transform: [{ translateX }] }]}
+                style={[
+                    styles.deleteAction,
+                    { transform: [{ translateX }], opacity },
+                ]}
             >
                 <TouchableOpacity
                     onPress={() => deleteAlarm(alarm.id)}
                     style={styles.deleteButton}
                 >
-                    <Text style={styles.deleteIcon}>🗑️</Text>
+                    <Text style={styles.deleteText}>삭제</Text>
                 </TouchableOpacity>
             </Animated.View>
         )
@@ -137,17 +145,21 @@ const styles = StyleSheet.create({
         color: '#888',
     },
     deleteAction: {
-        width: 80,
+        width: 88,
         height: '100%',
-        backgroundColor: '#4caf50',
+        backgroundColor: '#E6F4EA',
+        justifyContent: 'center',
+        alignItems: 'center',
     },
     deleteButton: {
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
     },
-    deleteIcon: {
-        fontSize: 24,
+    deleteText: {
+        color: '#2E7D32',
+        fontWeight: '600',
+        fontSize: 16,
     },
 })
 


### PR DESCRIPTION
## Summary
- Smoothly animate swipe delete action with drag and progress interpolation
- Restyle delete action with light green background and Korean "삭제" label
- Hide vertical scroll indicator on alarm list

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689773845624832eb2d5f954b079a763