### PR TITLE
Clamp AlarmRow swipe at delete action

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -68,7 +68,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 
     return (
         <View style={styles.wrapper}>
-            <Swipeable renderRightActions={renderRightActions}>
+            <Swipeable renderRightActions={renderRightActions} overshootRight={false}>
                 <View style={styles.container}>
                     <View style={styles.header}>
                         <Text style={styles.title}>{alarm.name}</Text>


### PR DESCRIPTION
## Summary
- Clamp AlarmRow swipeable translation so it stops once the delete action is fully visible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897772cf688832ea7ce1cfc42ec338b