### PR TITLE
Remove Home header and tighten list spacing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,11 @@ export default function App() {
       <GestureHandlerRootView style={{ flex: 1 }}>
         <NavigationContainer>
           <Stack.Navigator>
-            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen
+              name="Home"
+              component={HomeScreen}
+              options={{ headerShown: false }}
+            />
             <Stack.Screen name="CreateAlarm" component={CreateAlarmScreen} />
             <Stack.Screen name="EditAlarm" component={EditAlarmScreen} />
           </Stack.Navigator>

--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -29,7 +29,8 @@ const AlarmList = ({ alarms, deleteAlarm, updateAlarmDate, onEdit }: Props) => (
 
 const styles = StyleSheet.create({
     container: {
-        padding: 16,
+        paddingTop: 16,
+        paddingHorizontal: 0,
         paddingBottom: 80,
     },
 })

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -51,7 +51,14 @@ export default function HomeScreen() {
 
 
     return (
-        <View style={{ flex: 1, padding: 24, backgroundColor: '#f0fff4' }}>
+        <View
+            style={{
+                flex: 1,
+                paddingVertical: 24,
+                paddingHorizontal: 12,
+                backgroundColor: '#f0fff4',
+            }}
+        >
             <Text style={{ fontSize: 24, fontWeight: 'bold' }}>🕒 내 알람</Text>
 
             <AlarmList


### PR DESCRIPTION
## Summary
- hide default Home header by disabling navigation header
- reduce horizontal padding so alarm list sits closer to screen edges

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68977974df3c832eaa0c2a2ba7c52849