### PR TITLE
feat: redesign home screen layout and actions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,11 @@ export default function App() {
       <GestureHandlerRootView style={{ flex: 1 }}>
         <NavigationContainer>
           <Stack.Navigator>
-            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen
+              name="Home"
+              component={HomeScreen}
+              options={{ headerShown: false }}
+            />
             <Stack.Screen name="CreateAlarm" component={CreateAlarmScreen} />
             <Stack.Screen name="EditAlarm" component={EditAlarmScreen} />
           </Stack.Navigator>

--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -30,7 +30,7 @@ const AlarmList = ({ alarms, deleteAlarm, updateAlarmDate, onEdit }: Props) => (
 const styles = StyleSheet.create({
     container: {
         padding: 16,
-        paddingBottom: 80,
+        paddingBottom: 120,
     },
 })
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -77,12 +77,12 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                         <Text style={styles.title}>{alarm.name}</Text>
                         <View style={styles.actions}>
                             <TouchableOpacity onPress={() => onEdit(alarm.id)}>
-                                <Text style={styles.actionIcon}>✏️</Text>
+                                <Text style={styles.actionText}>수정</Text>
                             </TouchableOpacity>
                             <TouchableOpacity
                                 onPress={() => updateAlarmDate(alarm.id)}
                             >
-                                <Text style={styles.actionIcon}>🔁</Text>
+                                <Text style={styles.actionText}>갱신</Text>
                             </TouchableOpacity>
                         </View>
                     </View>
@@ -131,9 +131,10 @@ const styles = StyleSheet.create({
     actions: {
         flexDirection: 'row',
     },
-    actionIcon: {
-        fontSize: 20,
+    actionText: {
+        fontSize: 16,
         marginLeft: 12,
+        color: '#2E7D32',
     },
     progress: {
         marginTop: 12,

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity } from 'react-native'
+import { Text, TouchableOpacity, StyleSheet } from 'react-native'
 import AlarmList from '../components/AlarmList'
 import { useNavigation } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
@@ -7,12 +7,14 @@ import { Alarm } from '../types/Alarm'
 import { useFocusEffect } from '@react-navigation/native'
 import { useState, useCallback } from 'react'
 import { RootStackParamList } from '../types/navigation'
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export default function HomeScreen() {
     const navigation = useNavigation<
         NativeStackNavigationProp<RootStackParamList, 'Home'>
     >()
     const [alarms, setAlarms] = useState<Alarm[]>([])
+    const insets = useSafeAreaInsets()
 
     useFocusEffect(
         useCallback(() => {
@@ -51,7 +53,9 @@ export default function HomeScreen() {
 
 
     return (
-        <View style={{ flex: 1, padding: 24, backgroundColor: '#f0fff4' }}>
+        <SafeAreaView
+            style={{ flex: 1, padding: 24, backgroundColor: '#f0fff4' }}
+        >
             <Text style={{ fontSize: 24, fontWeight: 'bold' }}>🕒 내 알람</Text>
 
             <AlarmList
@@ -61,19 +65,36 @@ export default function HomeScreen() {
                 onEdit={(id) => navigation.navigate('EditAlarm', { id })}
             />
 
-            <View style={{ marginTop: 24 }}>
-                <TouchableOpacity
-                    onPress={() => navigation.navigate('CreateAlarm')}
-                    style={{
-                        backgroundColor: '#4caf50',
-                        paddingVertical: 12,
-                        borderRadius: 8,
-                        alignItems: 'center',
-                    }}
-                >
-                    <Text style={{ color: 'white', fontWeight: 'bold' }}>➕ 알람 등록</Text>
-                </TouchableOpacity>
-            </View>
-        </View>
+            <TouchableOpacity
+                onPress={() => navigation.navigate('CreateAlarm')}
+                style={[styles.fab, { bottom: insets.bottom + 24 }]}
+            >
+                <Text style={styles.fabText}>+</Text>
+            </TouchableOpacity>
+        </SafeAreaView>
     )
 }
+
+const styles = StyleSheet.create({
+    fab: {
+        position: 'absolute',
+        alignSelf: 'center',
+        width: 56,
+        height: 56,
+        borderRadius: 28,
+        backgroundColor: '#4caf50',
+        justifyContent: 'center',
+        alignItems: 'center',
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.3,
+        shadowRadius: 4,
+        elevation: 5,
+    },
+    fabText: {
+        color: '#fff',
+        fontSize: 32,
+        fontWeight: 'bold',
+        lineHeight: 32,
+    },
+})


### PR DESCRIPTION
## Summary
- hide Home stack header and apply safe area handling
- replace alarm row emojis with text labels
- add centered floating action button for creating alarms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68977cba14f0832eac49d383c708948f