### PR TITLE
Remove Home header, add safe area, replace icons with text

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,10 +11,14 @@ const Stack = createNativeStackNavigator<RootStackParamList>()
 
 export default function App() {
   return (
-      <GestureHandlerRootView style={{ flex: 1 }}>
+          <GestureHandlerRootView style={{ flex: 1 }}>
         <NavigationContainer>
           <Stack.Navigator>
-            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen
+              name="Home"
+              component={HomeScreen}
+              options={{ headerShown: false }}
+            />
             <Stack.Screen name="CreateAlarm" component={CreateAlarmScreen} />
             <Stack.Screen name="EditAlarm" component={EditAlarmScreen} />
           </Stack.Navigator>

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -77,12 +77,12 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                         <Text style={styles.title}>{alarm.name}</Text>
                         <View style={styles.actions}>
                             <TouchableOpacity onPress={() => onEdit(alarm.id)}>
-                                <Text style={styles.actionIcon}>✏️</Text>
+                                <Text style={styles.actionIcon}>수정</Text>
                             </TouchableOpacity>
                             <TouchableOpacity
                                 onPress={() => updateAlarmDate(alarm.id)}
                             >
-                                <Text style={styles.actionIcon}>🔁</Text>
+                                <Text style={styles.actionIcon}>갱신</Text>
                             </TouchableOpacity>
                         </View>
                     </View>
@@ -132,7 +132,7 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
     },
     actionIcon: {
-        fontSize: 20,
+        fontSize: 16,
         marginLeft: 12,
     },
     progress: {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,5 @@
 import { View, Text, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import AlarmList from '../components/AlarmList'
 import { useNavigation } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
@@ -51,7 +52,9 @@ export default function HomeScreen() {
 
 
     return (
-        <View style={{ flex: 1, padding: 24, backgroundColor: '#f0fff4' }}>
+        <SafeAreaView
+            style={{ flex: 1, padding: 24, backgroundColor: '#f0fff4' }}
+        >
             <Text style={{ fontSize: 24, fontWeight: 'bold' }}>🕒 내 알람</Text>
 
             <AlarmList
@@ -74,6 +77,6 @@ export default function HomeScreen() {
                     <Text style={{ color: 'white', fontWeight: 'bold' }}>➕ 알람 등록</Text>
                 </TouchableOpacity>
             </View>
-        </View>
+        </SafeAreaView>
     )
 }


### PR DESCRIPTION
## Summary
- Hide default header on Home screen to remove redundant title.
- Wrap Home screen with SafeAreaView to avoid covering iOS status bar.
- Replace edit and refresh emojis with Korean text labels.

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68977ea07e94832e9fd2bd7d07750490