### PR TITLE
Remove Home header and update alarm actions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,7 +14,11 @@ export default function App() {
       <GestureHandlerRootView style={{ flex: 1 }}>
         <NavigationContainer>
           <Stack.Navigator>
-            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen
+              name="Home"
+              component={HomeScreen}
+              options={{ headerShown: false }}
+            />
             <Stack.Screen name="CreateAlarm" component={CreateAlarmScreen} />
             <Stack.Screen name="EditAlarm" component={EditAlarmScreen} />
           </Stack.Navigator>

--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -29,7 +29,7 @@ const AlarmList = ({ alarms, deleteAlarm, updateAlarmDate, onEdit }: Props) => (
 
 const styles = StyleSheet.create({
     container: {
-        padding: 16,
+        paddingTop: 16,
         paddingBottom: 80,
     },
 })

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -77,12 +77,12 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                         <Text style={styles.title}>{alarm.name}</Text>
                         <View style={styles.actions}>
                             <TouchableOpacity onPress={() => onEdit(alarm.id)}>
-                                <Text style={styles.actionIcon}>✏️</Text>
+                                <Text style={styles.actionText}>수정</Text>
                             </TouchableOpacity>
                             <TouchableOpacity
                                 onPress={() => updateAlarmDate(alarm.id)}
                             >
-                                <Text style={styles.actionIcon}>🔁</Text>
+                                <Text style={styles.actionText}>갱신</Text>
                             </TouchableOpacity>
                         </View>
                     </View>
@@ -112,7 +112,6 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 const styles = StyleSheet.create({
     wrapper: {
         marginVertical: 8,
-        borderRadius: 12,
         overflow: 'hidden',
     },
     container: {
@@ -131,8 +130,8 @@ const styles = StyleSheet.create({
     actions: {
         flexDirection: 'row',
     },
-    actionIcon: {
-        fontSize: 20,
+    actionText: {
+        fontSize: 16,
         marginLeft: 12,
     },
     progress: {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,5 @@
 import { View, Text, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import AlarmList from '../components/AlarmList'
 import { useNavigation } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
@@ -51,8 +52,14 @@ export default function HomeScreen() {
 
 
     return (
-        <View style={{ flex: 1, padding: 24, backgroundColor: '#f0fff4' }}>
-            <Text style={{ fontSize: 24, fontWeight: 'bold' }}>🕒 내 알람</Text>
+        <SafeAreaView
+            style={{ flex: 1, backgroundColor: '#f0fff4', paddingTop: 24 }}
+        >
+            <Text
+                style={{ fontSize: 24, fontWeight: 'bold', marginHorizontal: 24 }}
+            >
+                🕒 내 알람
+            </Text>
 
             <AlarmList
                 alarms={alarms}
@@ -61,7 +68,7 @@ export default function HomeScreen() {
                 onEdit={(id) => navigation.navigate('EditAlarm', { id })}
             />
 
-            <View style={{ marginTop: 24 }}>
+            <View style={{ marginTop: 24, marginHorizontal: 24 }}>
                 <TouchableOpacity
                     onPress={() => navigation.navigate('CreateAlarm')}
                     style={{
@@ -71,9 +78,11 @@ export default function HomeScreen() {
                         alignItems: 'center',
                     }}
                 >
-                    <Text style={{ color: 'white', fontWeight: 'bold' }}>➕ 알람 등록</Text>
+                    <Text style={{ color: 'white', fontWeight: 'bold' }}>
+                        ➕ 알람 등록
+                    </Text>
                 </TouchableOpacity>
             </View>
-        </View>
+        </SafeAreaView>
     )
 }


### PR DESCRIPTION
## Summary
- hide default Home stack header
- ensure Home screen respects iOS safe area and align list items to screen edges
- replace pencil and refresh emojis with "수정" and "갱신" text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897805abea8832ea762f2f1a4d994bb