### PR TITLE
Adjust alarm swipe actions

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -39,7 +39,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     const TOTAL_WIDTH = ACTION_WIDTH * 2
 
     const renderRightActions = (
-        swipeProgress: Animated.AnimatedInterpolation<number>,
+        _progress: Animated.AnimatedInterpolation<number>,
         dragX: Animated.AnimatedInterpolation<number>
     ) => {
         const translateX = dragX.interpolate({
@@ -48,8 +48,14 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
             extrapolate: 'clamp',
         })
 
-        const actionWidth = swipeProgress.interpolate({
-            inputRange: [0, 1],
+        const reveal = dragX.interpolate({
+            inputRange: [-TOTAL_WIDTH, 0],
+            outputRange: [TOTAL_WIDTH, 0],
+            extrapolate: 'clamp',
+        })
+
+        const actionWidth = reveal.interpolate({
+            inputRange: [0, TOTAL_WIDTH],
             outputRange: [0, ACTION_WIDTH],
             extrapolate: 'clamp',
         })
@@ -154,7 +160,6 @@ const styles = StyleSheet.create({
     container: {
         backgroundColor: '#fff',
         padding: 16,
-        borderRadius: 16,
     },
     header: {
         flexDirection: 'row',

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -109,6 +109,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                 overshootRight={false}
                 friction={3}
                 rightThreshold={40}
+                useNativeAnimations={false}
             >
                 <View style={styles.container}>
                     <View style={styles.header}>

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -35,12 +35,11 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
         alarm.interval
     )
 
-    const EDIT_WIDTH = 72
-    const DELETE_WIDTH = 88
-    const TOTAL_WIDTH = EDIT_WIDTH + DELETE_WIDTH
+    const ACTION_WIDTH = 80
+    const TOTAL_WIDTH = ACTION_WIDTH * 2
 
     const renderRightActions = (
-        progress: Animated.AnimatedInterpolation<number>,
+        swipeProgress: Animated.AnimatedInterpolation<number>,
         dragX: Animated.AnimatedInterpolation<number>
     ) => {
         const translateX = dragX.interpolate({
@@ -48,34 +47,57 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
             outputRange: [0, TOTAL_WIDTH],
             extrapolate: 'clamp',
         })
-        const opacity = progress.interpolate({
+
+        const actionWidth = swipeProgress.interpolate({
             inputRange: [0, 1],
-            outputRange: [0, 1],
+            outputRange: [0, ACTION_WIDTH],
+            extrapolate: 'clamp',
         })
 
         return (
             <Animated.View
                 style={[
                     styles.actionsContainer,
-                    { transform: [{ translateX }], opacity },
+                    {
+                        width: TOTAL_WIDTH,
+                        transform: [{ translateX }],
+                    },
                 ]}
             >
-                <View style={[styles.editAction, { width: EDIT_WIDTH }]}>
+                <Animated.View
+                    style={[
+                        styles.action,
+                        styles.editAction,
+                        {
+                            width: actionWidth,
+                            right: actionWidth,
+                        },
+                    ]}
+                >
                     <TouchableOpacity
                         onPress={() => onEdit(alarm)}
                         style={styles.actionButton}
                     >
-                        <Text style={styles.editText}>수정</Text>
+                        <Text style={styles.actionLabel}>수정</Text>
                     </TouchableOpacity>
-                </View>
-                <View style={[styles.deleteAction, { width: DELETE_WIDTH }]}>
+                </Animated.View>
+                <Animated.View
+                    style={[
+                        styles.action,
+                        styles.deleteAction,
+                        {
+                            width: actionWidth,
+                            right: 0,
+                        },
+                    ]}
+                >
                     <TouchableOpacity
                         onPress={() => deleteAlarm(alarm.id)}
                         style={styles.actionButton}
                     >
-                        <Text style={styles.deleteText}>삭제</Text>
+                        <Text style={styles.actionLabel}>삭제</Text>
                     </TouchableOpacity>
-                </View>
+                </Animated.View>
             </Animated.View>
         )
     }
@@ -163,32 +185,28 @@ const styles = StyleSheet.create({
     },
     actionsContainer: {
         height: '100%',
-        flexDirection: 'row',
+        overflow: 'hidden',
+    },
+    action: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        justifyContent: 'center',
+        alignItems: 'center',
     },
     editAction: {
-        height: '100%',
-        backgroundColor: '#FFF3E0',
-        justifyContent: 'center',
-        alignItems: 'center',
+        backgroundColor: '#81C784',
     },
     deleteAction: {
-        height: '100%',
-        backgroundColor: '#E6F4EA',
-        justifyContent: 'center',
-        alignItems: 'center',
+        backgroundColor: '#388E3C',
     },
     actionButton: {
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
     },
-    editText: {
-        color: '#FF9800',
-        fontWeight: '600',
-        fontSize: 16,
-    },
-    deleteText: {
-        color: '#2E7D32',
+    actionLabel: {
+        color: '#ffffff',
         fontWeight: '600',
         fontSize: 16,
     },

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -39,7 +39,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     const TOTAL_WIDTH = ACTION_WIDTH * 2
 
     const renderRightActions = (
-        _progress: Animated.AnimatedInterpolation<number>,
+        swipeProgress: Animated.AnimatedInterpolation<number>,
         dragX: Animated.AnimatedInterpolation<number>
     ) => {
         const translateX = dragX.interpolate({
@@ -48,14 +48,8 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
             extrapolate: 'clamp',
         })
 
-        const reveal = dragX.interpolate({
-            inputRange: [-TOTAL_WIDTH, 0],
-            outputRange: [TOTAL_WIDTH, 0],
-            extrapolate: 'clamp',
-        })
-
-        const actionWidth = reveal.interpolate({
-            inputRange: [0, TOTAL_WIDTH],
+        const actionWidth = swipeProgress.interpolate({
+            inputRange: [0, 1],
             outputRange: [0, ACTION_WIDTH],
             extrapolate: 'clamp',
         })
@@ -160,6 +154,7 @@ const styles = StyleSheet.create({
     container: {
         backgroundColor: '#fff',
         padding: 16,
+        borderRadius: 16,
     },
     header: {
         flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Display edit and delete actions together when swiping an alarm
- Balance action sizes and tones using green shades and shared text styles

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689784931960832ebf60c8ff53b038c3