### PR TITLE
Fix spacing between list item and edit button on swipe

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -70,7 +70,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                         styles.editAction,
                         {
                             width: actionWidth,
-                            right: actionWidth,
+                            left: 0,
                         },
                     ]}
                 >
@@ -87,7 +87,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                         styles.deleteAction,
                         {
                             width: actionWidth,
-                            right: 0,
+                            left: actionWidth,
                         },
                     ]}
                 >


### PR DESCRIPTION
## Summary
- Align edit and delete buttons directly against list items during swipe

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68978cdfcdc0832e993589ff12f1598c