### PR TITLE
Fix edit button spacing for swipe actions

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -70,7 +70,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                         styles.editAction,
                         {
                             width: actionWidth,
-                            right: actionWidth,
+                            right: 0,
                         },
                     ]}
                 >
@@ -87,7 +87,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                         styles.deleteAction,
                         {
                             width: actionWidth,
-                            right: 0,
+                            right: actionWidth,
                         },
                     ]}
                 >


### PR DESCRIPTION
## Summary
- ensure swipe edit button sits flush against list item with no gap

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68978cdfcdc0832e993589ff12f1598c