### PR TITLE
Replace refresh text with button and add list item borders

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 import {
     View,
     Text,
-    TouchableOpacity,
     StyleSheet,
     Animated,
+    Button,
+    TouchableOpacity,
 } from 'react-native'
 import { Swipeable } from 'react-native-gesture-handler'
 import * as Progress from 'react-native-progress'
@@ -115,11 +116,12 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                     <View style={styles.header}>
                         <Text style={styles.title}>{alarm.name}</Text>
                         <View style={styles.actions}>
-                            <TouchableOpacity
-                                onPress={() => updateAlarmDate(alarm.id)}
-                            >
-                                <Text style={styles.actionText}>갱신</Text>
-                            </TouchableOpacity>
+                            <View style={styles.refreshButton}>
+                                <Button
+                                    title="갱신"
+                                    onPress={() => updateAlarmDate(alarm.id)}
+                                />
+                            </View>
                         </View>
                     </View>
                     <Progress.Bar
@@ -155,6 +157,8 @@ const styles = StyleSheet.create({
         backgroundColor: '#fff',
         padding: 16,
         borderRadius: 16,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: '#e0e0e0',
     },
     header: {
         flexDirection: 'row',
@@ -168,8 +172,7 @@ const styles = StyleSheet.create({
     actions: {
         flexDirection: 'row',
     },
-    actionText: {
-        fontSize: 16,
+    refreshButton: {
         marginLeft: 12,
     },
     progress: {


### PR DESCRIPTION
## Summary
- Replace refresh action text with a button for clearer interaction
- Add subtle light-gray borders to alarm list items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68978f711d98832e9e07969090f2a194