### PR TITLE
Add centered floating alarm creation button

### DIFF
--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -65,24 +65,34 @@ export default function HomeScreen() {
                 alarms={alarms}
                 deleteAlarm={deleteAlarm}
                 updateAlarmDate={updateAlarmDate}
-                onEdit={(alarm) => navigation.navigate('EditAlarm', { id: alarm.id })}
+                onEdit={(alarm) =>
+                    navigation.navigate('EditAlarm', { id: alarm.id })
+                }
             />
 
-            <View style={{ marginTop: 24, marginHorizontal: 24 }}>
-                <TouchableOpacity
-                    onPress={() => navigation.navigate('CreateAlarm')}
-                    style={{
-                        backgroundColor: '#4caf50',
-                        paddingVertical: 12,
-                        borderRadius: 8,
-                        alignItems: 'center',
-                    }}
-                >
-                    <Text style={{ color: 'white', fontWeight: 'bold' }}>
-                        ➕ 알람 등록
-                    </Text>
-                </TouchableOpacity>
-            </View>
+            <TouchableOpacity
+                onPress={() => navigation.navigate('CreateAlarm')}
+                style={{
+                    position: 'absolute',
+                    bottom: 24,
+                    alignSelf: 'center',
+                    width: 64,
+                    height: 64,
+                    borderRadius: 32,
+                    backgroundColor: '#4caf50',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    shadowColor: '#000',
+                    shadowOffset: { width: 0, height: 2 },
+                    shadowOpacity: 0.3,
+                    shadowRadius: 4,
+                    elevation: 5,
+                }}
+            >
+                <Text style={{ fontSize: 32, color: 'white', fontWeight: 'bold' }}>
+                    +
+                </Text>
+            </TouchableOpacity>
         </SafeAreaView>
     )
 }


### PR DESCRIPTION
## Summary
- Place a floating circular add-alarm button centered at the bottom of the Home screen
- Style button with green theme and plus icon for adding alarms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689791dcb00c832eb40a311eb0360c7c