### PR TITLE
feat: reposition alarm registration button and refine list style

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { FlatList, StyleSheet } from 'react-native'
+import {
+    FlatList,
+    StyleSheet,
+    TouchableOpacity,
+    View,
+    Text,
+} from 'react-native'
 import AlarmRow from './AlarmRow'
 import { Alarm } from '../types/Alarm'
 
@@ -8,9 +14,16 @@ type Props = {
     deleteAlarm: (id: string) => void
     updateAlarmDate: (id: string) => void
     onEdit: (alarm: Alarm) => void
+    onAdd: () => void
 }
 
-const AlarmList = ({ alarms, deleteAlarm, updateAlarmDate, onEdit }: Props) => (
+const AlarmList = ({
+    alarms,
+    deleteAlarm,
+    updateAlarmDate,
+    onEdit,
+    onAdd,
+}: Props) => (
     <FlatList
         data={alarms}
         keyExtractor={(item) => item.id}
@@ -24,13 +37,41 @@ const AlarmList = ({ alarms, deleteAlarm, updateAlarmDate, onEdit }: Props) => (
         )}
         contentContainerStyle={styles.container}
         showsVerticalScrollIndicator={false}
+        ListFooterComponent=
+            <View style={styles.footer}>
+                <TouchableOpacity onPress={onAdd} style={styles.addButton}>
+                    <Text style={styles.addButtonText}>+</Text>
+                </TouchableOpacity>
+            </View>
     />
 )
 
 const styles = StyleSheet.create({
     container: {
         paddingTop: 16,
-        paddingBottom: 80,
+        paddingBottom: 16,
+    },
+    footer: {
+        paddingVertical: 24,
+        alignItems: 'center',
+    },
+    addButton: {
+        width: 64,
+        height: 64,
+        borderRadius: 32,
+        backgroundColor: '#4caf50',
+        justifyContent: 'center',
+        alignItems: 'center',
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.3,
+        shadowRadius: 4,
+        elevation: 5,
+    },
+    addButtonText: {
+        fontSize: 32,
+        color: '#fff',
+        fontWeight: 'bold',
     },
 })
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -157,7 +157,7 @@ const styles = StyleSheet.create({
         padding: 16,
         borderRadius: 16,
         borderWidth: StyleSheet.hairlineWidth,
-        borderColor: '#e0e0e0',
+        borderColor: '#66bb6a',
     },
     header: {
         flexDirection: 'row',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity } from 'react-native'
+import { Text } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import AlarmList from '../components/AlarmList'
 import { useNavigation } from '@react-navigation/native'
@@ -68,31 +68,8 @@ export default function HomeScreen() {
                 onEdit={(alarm) =>
                     navigation.navigate('EditAlarm', { id: alarm.id })
                 }
+                onAdd={() => navigation.navigate('CreateAlarm')}
             />
-
-            <TouchableOpacity
-                onPress={() => navigation.navigate('CreateAlarm')}
-                style={{
-                    position: 'absolute',
-                    bottom: 24,
-                    alignSelf: 'center',
-                    width: 64,
-                    height: 64,
-                    borderRadius: 32,
-                    backgroundColor: '#4caf50',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    shadowColor: '#000',
-                    shadowOffset: { width: 0, height: 2 },
-                    shadowOpacity: 0.3,
-                    shadowRadius: 4,
-                    elevation: 5,
-                }}
-            >
-                <Text style={{ fontSize: 32, color: 'white', fontWeight: 'bold' }}>
-                    +
-                </Text>
-            </TouchableOpacity>
         </SafeAreaView>
     )
 }


### PR DESCRIPTION
## Summary
- move alarm creation button to list footer and center it beneath entries
- darken list item borders with green tone to match theme

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68979361f9bc832e8793767980bfa920