### PR TITLE
Center alarm creation button beneath list and darken item borders

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -8,9 +8,16 @@ type Props = {
     deleteAlarm: (id: string) => void
     updateAlarmDate: (id: string) => void
     onEdit: (alarm: Alarm) => void
+    footer?: React.ReactNode
 }
 
-const AlarmList = ({ alarms, deleteAlarm, updateAlarmDate, onEdit }: Props) => (
+const AlarmList = ({
+    alarms,
+    deleteAlarm,
+    updateAlarmDate,
+    onEdit,
+    footer,
+}: Props) => (
     <FlatList
         data={alarms}
         keyExtractor={(item) => item.id}
@@ -24,13 +31,14 @@ const AlarmList = ({ alarms, deleteAlarm, updateAlarmDate, onEdit }: Props) => (
         )}
         contentContainerStyle={styles.container}
         showsVerticalScrollIndicator={false}
+        ListFooterComponent={footer}
     />
 )
 
 const styles = StyleSheet.create({
     container: {
         paddingTop: 16,
-        paddingBottom: 80,
+        paddingBottom: 32,
     },
 })
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -157,7 +157,7 @@ const styles = StyleSheet.create({
         padding: 16,
         borderRadius: 16,
         borderWidth: StyleSheet.hairlineWidth,
-        borderColor: '#e0e0e0',
+        borderColor: '#bdbdbd',
     },
     header: {
         flexDirection: 'row',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity } from 'react-native'
+import { Text, TouchableOpacity } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import AlarmList from '../components/AlarmList'
 import { useNavigation } from '@react-navigation/native'
@@ -68,31 +68,38 @@ export default function HomeScreen() {
                 onEdit={(alarm) =>
                     navigation.navigate('EditAlarm', { id: alarm.id })
                 }
+                footer={
+                    <TouchableOpacity
+                        onPress={() => navigation.navigate('CreateAlarm')}
+                        style={{
+                            alignSelf: 'center',
+                            marginTop: 16,
+                            marginBottom: 32,
+                            width: 64,
+                            height: 64,
+                            borderRadius: 32,
+                            backgroundColor: '#4caf50',
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                            shadowColor: '#000',
+                            shadowOffset: { width: 0, height: 2 },
+                            shadowOpacity: 0.3,
+                            shadowRadius: 4,
+                            elevation: 5,
+                        }}
+                    >
+                        <Text
+                            style={{
+                                fontSize: 32,
+                                color: 'white',
+                                fontWeight: 'bold',
+                            }}
+                        >
+                            +
+                        </Text>
+                    </TouchableOpacity>
+                }
             />
-
-            <TouchableOpacity
-                onPress={() => navigation.navigate('CreateAlarm')}
-                style={{
-                    position: 'absolute',
-                    bottom: 24,
-                    alignSelf: 'center',
-                    width: 64,
-                    height: 64,
-                    borderRadius: 32,
-                    backgroundColor: '#4caf50',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    shadowColor: '#000',
-                    shadowOffset: { width: 0, height: 2 },
-                    shadowOpacity: 0.3,
-                    shadowRadius: 4,
-                    elevation: 5,
-                }}
-            >
-                <Text style={{ fontSize: 32, color: 'white', fontWeight: 'bold' }}>
-                    +
-                </Text>
-            </TouchableOpacity>
         </SafeAreaView>
     )
 }


### PR DESCRIPTION
## Summary
- Add optional footer to alarm list so UI elements can appear after the final item
- Move and style the alarm creation “+” button as a centered footer under the list
- Darken list item border color to improve contrast while keeping green theme

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68979361f9bc832e8793767980bfa920