### PR TITLE
feat: enhance alarm edit screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.24",
+    "@react-native-community/datetimepicker": "^8.0.0",
     "expo": "~53.0.20",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- allow editing alarm names and start dates with validation
- support calendar-based date selection
- ensure interval is a positive integer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm install @react-native-community/datetimepicker` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689796296148832eab8e3de20daf40fe