### PR TITLE
feat: confirmable modal for start date in edit alarm

### DIFF
--- a/screens/EditAlarmScreen.tsx
+++ b/screens/EditAlarmScreen.tsx
@@ -9,9 +9,7 @@ import {
     Modal,
 } from 'react-native'
 import { useState, useEffect } from 'react'
-import DateTimePicker, {
-    DateTimePickerAndroid,
-} from '@react-native-community/datetimepicker'
+import DateTimePicker from '@react-native-community/datetimepicker'
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import AsyncStorage from '@react-native-async-storage/async-storage'
@@ -29,6 +27,7 @@ export default function EditAlarmScreen() {
     const [interval, setInterval] = useState('')
     const [name, setName] = useState('')
     const [showPicker, setShowPicker] = useState(false)
+    const [tempDate, setTempDate] = useState(new Date())
     const [nameError, setNameError] = useState('')
     const [intervalError, setIntervalError] = useState('')
 
@@ -84,21 +83,16 @@ export default function EditAlarmScreen() {
     }
 
     const openPicker = () => {
-        if (Platform.OS === 'android') {
-            DateTimePickerAndroid.open({
-                value: startDate,
-                mode: 'date',
-                onChange: (_, date) => {
-                    if (date) setStartDate(date)
-                },
-            })
-        } else {
-            setShowPicker(true)
-        }
+        setTempDate(startDate)
+        setShowPicker(true)
     }
 
-    const onChangeDate = (_: any, selected?: Date) => {
-        if (selected) setStartDate(selected)
+    const confirmDate = () => {
+        setStartDate(tempDate)
+        setShowPicker(false)
+    }
+
+    const cancelPicker = () => {
         setShowPicker(false)
     }
 
@@ -116,15 +110,28 @@ export default function EditAlarmScreen() {
             <Pressable onPress={openPicker} style={styles.input}>
                 <Text>{startDate.toISOString().slice(0, 10)}</Text>
             </Pressable>
-            {Platform.OS !== 'android' && showPicker && (
-                <Modal transparent={true} animationType="slide">
-                    <DateTimePicker
-                        value={startDate}
-                        mode="date"
-                        display="spinner"
-                        onChange={onChangeDate}
-                        style={styles.modalPicker}
-                    />
+            {showPicker && (
+                <Modal transparent animationType="fade">
+                    <View style={styles.modalOverlay}>
+                        <View style={styles.modalContent}>
+                            <DateTimePicker
+                                value={tempDate}
+                                mode="date"
+                                display={
+                                    Platform.OS === 'ios' ? 'spinner' : 'calendar'
+                                }
+                                onChange={(_, date) => {
+                                    if (date) setTempDate(date)
+                                }}
+                                style={styles.modalPicker}
+                            />
+                            <View style={styles.modalButtons}>
+                                <Button title="취소" onPress={cancelPicker} />
+                                <View style={styles.buttonSpacer} />
+                                <Button title="확인" onPress={confirmDate} />
+                            </View>
+                        </View>
+                    </View>
                 </Modal>
             )}
 
@@ -167,5 +174,24 @@ const styles = StyleSheet.create({
     },
     modalPicker: {
         backgroundColor: '#fff',
+    },
+    modalOverlay: {
+        flex: 1,
+        backgroundColor: 'rgba(0,0,0,0.5)',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    modalContent: {
+        backgroundColor: '#fff',
+        borderRadius: 8,
+        padding: 16,
+    },
+    modalButtons: {
+        flexDirection: 'row',
+        justifyContent: 'flex-end',
+        marginTop: 16,
+    },
+    buttonSpacer: {
+        width: 8,
     },
 })


### PR DESCRIPTION
## Summary
- replace direct date saving with modal-based date picker that requires user confirmation
- center the date picker in a dimmed modal and handle cancelation

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68979cecef98832e8d9d3e26ef912749