### PR TITLE
Close swipe after edit and unify card rounding

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -2,12 +2,17 @@ import React from 'react'
 import { FlatList, StyleSheet } from 'react-native'
 import AlarmRow from './AlarmRow'
 import { Alarm } from '../types/Alarm'
+import { Swipeable } from 'react-native-gesture-handler'
 
 type Props = {
     alarms: Alarm[]
     deleteAlarm: (id: string) => void
     updateAlarmDate: (id: string) => void
-    onEdit: (alarm: Alarm, triggerRef: any) => void
+    onEdit: (
+        alarm: Alarm,
+        triggerRef: any,
+        swipeableRef: Swipeable | null
+    ) => void
     footer?: React.ReactElement | null
 }
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -14,7 +14,11 @@ type Props = {
     alarm: Alarm
     deleteAlarm: (id: string) => void
     updateAlarmDate: (id: string) => void
-    onEdit: (alarm: Alarm, triggerRef: any) => void
+    onEdit: (
+        alarm: Alarm,
+        triggerRef: any,
+        swipeableRef: Swipeable | null
+    ) => void
 }
 
 const calculateProgress = (createdAt: string, interval: number) => {
@@ -35,6 +39,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
         alarm.interval
     )
     const editRef = useRef<any>(null)
+    const swipeableRef = useRef<Swipeable | null>(null)
 
     const ACTION_WIDTH = 80
     const TOTAL_WIDTH = ACTION_WIDTH * 2
@@ -77,7 +82,9 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                 >
                     <TouchableOpacity
                         ref={editRef}
-                        onPress={() => onEdit(alarm, editRef.current)}
+                        onPress={() =>
+                            onEdit(alarm, editRef.current, swipeableRef.current)
+                        }
                         style={styles.actionButton}
                     >
                         <Text style={styles.actionLabel}>수정</Text>
@@ -107,6 +114,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     return (
         <View style={styles.wrapper}>
             <Swipeable
+                ref={swipeableRef}
                 renderRightActions={renderRightActions}
                 overshootRight={false}
                 friction={3}
@@ -153,13 +161,13 @@ const styles = StyleSheet.create({
         marginVertical: 8,
         borderRadius: 16,
         overflow: 'hidden',
+        backgroundColor: '#fff',
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: '#bdbdbd',
     },
     container: {
         backgroundColor: '#fff',
         padding: 16,
-        borderRadius: 16,
-        borderWidth: StyleSheet.hairlineWidth,
-        borderColor: '#bdbdbd',
     },
     header: {
         flexDirection: 'row',
@@ -199,6 +207,8 @@ const styles = StyleSheet.create({
     actionsContainer: {
         height: '100%',
         overflow: 'hidden',
+        borderTopRightRadius: 16,
+        borderBottomRightRadius: 16,
     },
     action: {
         position: 'absolute',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -7,6 +7,7 @@ import { useFocusEffect } from '@react-navigation/native'
 import { useState, useCallback, useRef } from 'react'
 import AddAlarmModal from '../components/AddAlarmModal'
 import EditAlarmModal from '../components/EditAlarmModal'
+import { Swipeable } from 'react-native-gesture-handler'
 
 export default function HomeScreen() {
     const [alarms, setAlarms] = useState<Alarm[]>([])
@@ -14,6 +15,7 @@ export default function HomeScreen() {
     const addButtonRef = useRef<any>(null)
     const [editingAlarm, setEditingAlarm] = useState<Alarm | null>(null)
     const editButtonRef = useRef<any>(null)
+    const editingSwipeRef = useRef<Swipeable | null>(null)
 
     useFocusEffect(
         useCallback(() => {
@@ -87,6 +89,8 @@ export default function HomeScreen() {
         )
         await AsyncStorage.setItem('alarms', JSON.stringify(updated))
         setAlarms(updated)
+        editingSwipeRef.current?.close()
+        editingSwipeRef.current = null
     }
 
 
@@ -104,8 +108,9 @@ export default function HomeScreen() {
                 alarms={alarms}
                 deleteAlarm={deleteAlarm}
                 updateAlarmDate={updateAlarmDate}
-                onEdit={(alarm, ref) => {
+                onEdit={(alarm, ref, swipeRef) => {
                     editButtonRef.current = ref
+                    editingSwipeRef.current = swipeRef
                     setEditingAlarm(alarm)
                 }}
                 footer={
@@ -154,6 +159,8 @@ export default function HomeScreen() {
                 alarm={editingAlarm}
                 onClose={() => {
                     setEditingAlarm(null)
+                    editingSwipeRef.current?.close()
+                    editingSwipeRef.current = null
                     editButtonRef.current?.focus?.()
                 }}
                 onSubmit={handleEdit}


### PR DESCRIPTION
## Summary
- close row swipe state after saving edits using stored Swipeable reference
- adjust card and action styling so list item and actions share one rounded outer border

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689828bda934832e94b9420b9b5187fc