### PR TITLE
Close alarm swipe after edits and unify rounded styling

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import { FlatList, StyleSheet } from 'react-native'
 import AlarmRow from './AlarmRow'
 import { Alarm } from '../types/Alarm'
+import type { Swipeable } from 'react-native-gesture-handler'
 
 type Props = {
     alarms: Alarm[]
     deleteAlarm: (id: string) => void
     updateAlarmDate: (id: string) => void
-    onEdit: (alarm: Alarm, triggerRef: any) => void
+    onEdit: (alarm: Alarm, triggerRef: any, swipeRef: Swipeable | null) => void
     footer?: React.ReactElement | null
 }
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -14,7 +14,7 @@ type Props = {
     alarm: Alarm
     deleteAlarm: (id: string) => void
     updateAlarmDate: (id: string) => void
-    onEdit: (alarm: Alarm, triggerRef: any) => void
+    onEdit: (alarm: Alarm, triggerRef: any, swipeRef: Swipeable | null) => void
 }
 
 const calculateProgress = (createdAt: string, interval: number) => {
@@ -35,6 +35,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
         alarm.interval
     )
     const editRef = useRef<any>(null)
+    const swipeRef = useRef<Swipeable | null>(null)
 
     const ACTION_WIDTH = 80
     const TOTAL_WIDTH = ACTION_WIDTH * 2
@@ -77,7 +78,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                 >
                     <TouchableOpacity
                         ref={editRef}
-                        onPress={() => onEdit(alarm, editRef.current)}
+                        onPress={() => onEdit(alarm, editRef.current, swipeRef.current)}
                         style={styles.actionButton}
                     >
                         <Text style={styles.actionLabel}>수정</Text>
@@ -107,6 +108,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     return (
         <View style={styles.wrapper}>
             <Swipeable
+                ref={swipeRef}
                 renderRightActions={renderRightActions}
                 overshootRight={false}
                 friction={3}
@@ -153,13 +155,12 @@ const styles = StyleSheet.create({
         marginVertical: 8,
         borderRadius: 16,
         overflow: 'hidden',
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: '#bdbdbd',
     },
     container: {
         backgroundColor: '#fff',
         padding: 16,
-        borderRadius: 16,
-        borderWidth: StyleSheet.hairlineWidth,
-        borderColor: '#bdbdbd',
     },
     header: {
         flexDirection: 'row',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -7,6 +7,7 @@ import { useFocusEffect } from '@react-navigation/native'
 import { useState, useCallback, useRef } from 'react'
 import AddAlarmModal from '../components/AddAlarmModal'
 import EditAlarmModal from '../components/EditAlarmModal'
+import type { Swipeable } from 'react-native-gesture-handler'
 
 export default function HomeScreen() {
     const [alarms, setAlarms] = useState<Alarm[]>([])
@@ -14,6 +15,7 @@ export default function HomeScreen() {
     const addButtonRef = useRef<any>(null)
     const [editingAlarm, setEditingAlarm] = useState<Alarm | null>(null)
     const editButtonRef = useRef<any>(null)
+    const swipeRowRef = useRef<Swipeable | null>(null)
 
     useFocusEffect(
         useCallback(() => {
@@ -87,6 +89,7 @@ export default function HomeScreen() {
         )
         await AsyncStorage.setItem('alarms', JSON.stringify(updated))
         setAlarms(updated)
+        swipeRowRef.current?.close()
     }
 
 
@@ -104,8 +107,9 @@ export default function HomeScreen() {
                 alarms={alarms}
                 deleteAlarm={deleteAlarm}
                 updateAlarmDate={updateAlarmDate}
-                onEdit={(alarm, ref) => {
+                onEdit={(alarm, ref, swipeRef) => {
                     editButtonRef.current = ref
+                    swipeRowRef.current = swipeRef
                     setEditingAlarm(alarm)
                 }}
                 footer={
@@ -155,6 +159,8 @@ export default function HomeScreen() {
                 onClose={() => {
                     setEditingAlarm(null)
                     editButtonRef.current?.focus?.()
+                    swipeRowRef.current?.close()
+                    swipeRowRef.current = null
                 }}
                 onSubmit={handleEdit}
             />


### PR DESCRIPTION
## Summary
- Close an alarm's swipeable row when edits are saved or the modal closes
- Style list items and swipe actions as a single card with only outer rounded corners

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689828bda934832e94b9420b9b5187fc