### PR TITLE
Limit alarm title length and keep refresh button aligned

### DIFF
--- a/components/AddAlarmModal.tsx
+++ b/components/AddAlarmModal.tsx
@@ -35,8 +35,9 @@ export default function AddAlarmModal({ visible, onClose, onSubmit }: Props) {
     }, [visible])
 
     const onChangeName = (text: string) => {
-        setName(text)
-        const trimmed = text.trim()
+        const limited = text.slice(0, 50)
+        setName(limited)
+        const trimmed = limited.trim()
         setNameError(trimmed ? '' : '알람 제목을 입력해 주세요.')
     }
 
@@ -84,6 +85,7 @@ export default function AddAlarmModal({ visible, onClose, onSubmit }: Props) {
                         onChangeText={onChangeName}
                         placeholder="예: 칫솔 교체"
                         autoFocus
+                        maxLength={50}
                     />
                     {nameError ? (
                         <Text style={styles.error}>{nameError}</Text>

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -183,9 +183,13 @@ const styles = StyleSheet.create({
     title: {
         fontSize: 20,
         fontWeight: 'bold',
+        flex: 1,
+        marginRight: 8,
+        flexWrap: 'wrap',
     },
     actions: {
         flexDirection: 'row',
+        flexShrink: 0,
     },
     refreshButton: {
         backgroundColor: '#4caf50',

--- a/components/EditAlarmModal.tsx
+++ b/components/EditAlarmModal.tsx
@@ -55,8 +55,9 @@ export default function EditAlarmModal({
     }, [visible, alarm])
 
     const onChangeName = (text: string) => {
-        setName(text)
-        const trimmed = text.trim()
+        const limited = text.slice(0, 50)
+        setName(limited)
+        const trimmed = limited.trim()
         setNameError(trimmed ? '' : '알람 제목을 입력해 주세요.')
     }
 
@@ -112,6 +113,7 @@ export default function EditAlarmModal({
                         value={name}
                         onChangeText={onChangeName}
                         autoFocus
+                        maxLength={50}
                     />
                     {nameError ? <Text style={styles.error}>{nameError}</Text> : null}
 


### PR DESCRIPTION
## Summary
- keep refresh button pinned to the right by allowing alarm title to wrap without pushing layout
- limit alarm titles to 50 characters in add and edit modals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68984994a240832eadb132e194763115