### PR TITLE
Limit alarm title length and stabilize layout

### DIFF
--- a/components/AddAlarmModal.tsx
+++ b/components/AddAlarmModal.tsx
@@ -82,6 +82,7 @@ export default function AddAlarmModal({ visible, onClose, onSubmit }: Props) {
                         style={styles.input}
                         value={name}
                         onChangeText={onChangeName}
+                        maxLength={50}
                         placeholder="예: 칫솔 교체"
                         autoFocus
                     />

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -126,7 +126,13 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
             >
                 <View style={styles.container}>
                     <View style={styles.header}>
-                        <Text style={styles.title}>{alarm.name}</Text>
+                        <Text
+                            style={styles.title}
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                        >
+                            {alarm.name}
+                        </Text>
                         <View style={styles.actions}>
                             <TouchableOpacity
                                 onPress={() => updateAlarmDate(alarm.id)}
@@ -177,12 +183,14 @@ const styles = StyleSheet.create({
     },
     header: {
         flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'flex-start',
+        alignItems: 'center',
     },
     title: {
+        flex: 1,
         fontSize: 20,
         fontWeight: 'bold',
+        marginRight: 8,
+        flexShrink: 1,
     },
     actions: {
         flexDirection: 'row',

--- a/components/EditAlarmModal.tsx
+++ b/components/EditAlarmModal.tsx
@@ -111,6 +111,7 @@ export default function EditAlarmModal({
                         style={styles.input}
                         value={name}
                         onChangeText={onChangeName}
+                        maxLength={50}
                         autoFocus
                     />
                     {nameError ? <Text style={styles.error}>{nameError}</Text> : null}


### PR DESCRIPTION
## Summary
- limit alarm title input to 50 characters when adding or editing
- keep refresh button fixed with long titles by truncating and adjusting layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68984994a240832eadb132e194763115