### PR TITLE
feat: show due indicator and format dates

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -9,6 +9,7 @@ import {
 import { Swipeable } from 'react-native-gesture-handler'
 import * as Progress from 'react-native-progress'
 import { Alarm } from '../types/Alarm'
+import formatDate from '../utils/date'
 
 type Props = {
     alarm: Alarm
@@ -138,7 +139,10 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                                 onPress={() => updateAlarmDate(alarm.id)}
                                 style={styles.refreshButton}
                             >
-                                <Text style={styles.refreshButtonText}>갱신</Text>
+                                <View style={styles.refreshContent}>
+                                    <Text style={styles.refreshButtonText}>갱신</Text>
+                                    {isDue && <View style={styles.dueDot} />}
+                                </View>
                             </TouchableOpacity>
                         </View>
                     </View>
@@ -153,7 +157,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                     />
                     <View style={styles.footer}>
                         <Text style={styles.subText}>
-                            시작일: {new Date(alarm.createdAt).toLocaleDateString()}
+                            시작일: {formatDate(new Date(alarm.createdAt))}
                         </Text>
                         <Text style={styles.subText}>
                             남은 일수: {remainingDays}일
@@ -167,7 +171,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 
 const styles = StyleSheet.create({
     wrapper: {
-        marginVertical: 8,
+        marginVertical: 4,
         borderRadius: 16,
         overflow: 'hidden',
         backgroundColor: '#fff',
@@ -201,10 +205,21 @@ const styles = StyleSheet.create({
         paddingHorizontal: 12,
         borderRadius: 8,
     },
+    refreshContent: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
     refreshButtonText: {
         color: '#fff',
         fontSize: 14,
         fontWeight: '500',
+    },
+    dueDot: {
+        width: 6,
+        height: 6,
+        borderRadius: 3,
+        backgroundColor: '#f44336',
+        marginLeft: 4,
     },
     progress: {
         marginTop: 12,

--- a/components/EditAlarmModal.tsx
+++ b/components/EditAlarmModal.tsx
@@ -14,6 +14,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 import DateTimePicker from '@react-native-community/datetimepicker'
 import { Alarm } from '../types/Alarm'
+import formatDate from '../utils/date'
 
 interface Props {
     visible: boolean
@@ -118,7 +119,7 @@ export default function EditAlarmModal({
 
                     <Text style={styles.label}>시작일</Text>
                     <Pressable onPress={openPicker} style={styles.input}>
-                        <Text>{startDate.toISOString().slice(0, 10)}</Text>
+                        <Text>{formatDate(startDate)}</Text>
                     </Pressable>
                     {showPicker && (
                         <Modal transparent animationType="fade">

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,0 +1,8 @@
+export const formatDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}/${month}/${day}`;
+};
+
+export default formatDate;


### PR DESCRIPTION
## Summary
- show tiny red dot next to refresh button when alarm is due
- format start date as YYYY/MM/DD across UI
- tighten list item spacing for denser layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68984f8ead0c832e830eb056d28b715a