### PR TITLE
feat: highlight completed alarms

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -5,6 +5,7 @@ import {
     TouchableOpacity,
     StyleSheet,
     Animated,
+    Image,
 } from 'react-native'
 import { Swipeable } from 'react-native-gesture-handler'
 import * as Progress from 'react-native-progress'
@@ -132,7 +133,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                 rightThreshold={40}
                 useNativeAnimations={false}
             >
-                <View style={styles.container}>
+                <View style={[styles.container, isDue && styles.dueContainer]}>
                     <View style={styles.header}>
                         <Text
                             style={styles.title}
@@ -153,15 +154,22 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                             </TouchableOpacity>
                         </View>
                     </View>
-                    <Progress.Bar
-                        progress={progress}
-                        width={null}
-                        height={14}
-                        borderRadius={7}
-                        color={progressColor}
-                        unfilledColor="#e0f2f1"
-                        style={styles.progress}
-                    />
+                    <View style={styles.progressWrapper}>
+                        <Progress.Bar
+                            progress={progress}
+                            width={null}
+                            height={14}
+                            borderRadius={7}
+                            color={progressColor}
+                            unfilledColor="#e0f2f1"
+                        />
+                        {isDue && (
+                            <Image
+                                source={require('../assets/alarm.png')}
+                                style={styles.progressIcon}
+                            />
+                        )}
+                    </View>
                     <View style={styles.footer}>
                         <Text style={styles.subText}>
                             시작일: {formatDate(alarm.createdAt)}
@@ -187,10 +195,14 @@ const styles = StyleSheet.create({
     },
     dueWrapper: {
         borderColor: '#757575',
+        backgroundColor: '#e8f5e9',
     },
     container: {
         backgroundColor: '#fff',
         padding: 12,
+    },
+    dueContainer: {
+        backgroundColor: '#e8f5e9',
     },
     header: {
         flexDirection: 'row',
@@ -228,8 +240,17 @@ const styles = StyleSheet.create({
         fontSize: 14,
         fontWeight: '500',
     },
-    progress: {
+    progressWrapper: {
         marginTop: 8,
+        position: 'relative',
+        justifyContent: 'center',
+    },
+    progressIcon: {
+        position: 'absolute',
+        right: -7,
+        width: 14,
+        height: 14,
+        resizeMode: 'contain',
     },
     footer: {
         flexDirection: 'row',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import { Text, TouchableOpacity } from 'react-native'
+import { Text, TouchableOpacity, View, Image } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import AlarmList from '../components/AlarmList'
 import AsyncStorage from '@react-native-async-storage/async-storage'
@@ -98,11 +98,21 @@ export default function HomeScreen() {
         <SafeAreaView
             style={{ flex: 1, backgroundColor: '#f0fff4', paddingTop: 24 }}
         >
-            <Text
-                style={{ fontSize: 24, fontWeight: 'bold', marginHorizontal: 24 }}
+            <View
+                style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    marginHorizontal: 24,
+                }}
             >
-                🕒 내 알람
-            </Text>
+                <Image
+                    source={require('../assets/alarm.png')}
+                    style={{ width: 24, height: 24, marginRight: 8 }}
+                />
+                <Text style={{ fontSize: 24, fontWeight: 'bold' }}>
+                    내 알람
+                </Text>
+            </View>
 
             <AlarmList
                 alarms={alarms}


### PR DESCRIPTION
## Summary
- show alarm icon next to progress bar when alarm is due
- tint completed alarm rows with light green background
- replace header emoji with alarm icon

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68987ce94b44832eb20064b119024ac7