### PR TITLE
style: adjust list borders and icons

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -191,11 +191,11 @@ const styles = StyleSheet.create({
         borderRadius: 16,
         overflow: 'hidden',
         backgroundColor: '#fff',
-        borderWidth: StyleSheet.hairlineWidth,
-        borderColor: '#bdbdbd',
+        borderWidth: 2,
+        borderColor: '#006400',
     },
     dueWrapper: {
-        borderColor: '#757575',
+        borderColor: '#FFD700',
         backgroundColor: '#e8f5e9',
     },
     container: {
@@ -249,12 +249,12 @@ const styles = StyleSheet.create({
     progress: {},
     progressIcon: {
         position: 'absolute',
-        right: -10,
+        right: -12,
         top: '50%',
-        width: 20,
-        height: 20,
+        width: 24,
+        height: 24,
         resizeMode: 'contain',
-        transform: [{ translateY: -10 }],
+        transform: [{ translateY: -12 }],
     },
     footer: {
         flexDirection: 'row',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -105,11 +105,11 @@ export default function HomeScreen() {
                     marginHorizontal: 24,
                 }}
             >
+                <Text style={{ fontSize: 24, fontWeight: 'bold' }}>내 알람</Text>
                 <Image
                     source={require('../assets/alarm.png')}
-                    style={{ width: 24, height: 24, marginRight: 8 }}
+                    style={{ width: 28, height: 28, marginLeft: 8 }}
                 />
-                <Text style={{ fontSize: 24, fontWeight: 'bold' }}>내 알람</Text>
             </View>
 
             <AlarmList


### PR DESCRIPTION
## Summary
- thicken list borders and color them dark green by default
- highlight fully due alarms with golden borders and larger progress icons
- move header alarm icon to right of "내 알람" and enlarge it

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68988706384c832ea63ade4b7429afe3