### PR TITLE
Align renew button color with progress and refresh header icon

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -145,7 +145,10 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                         <View style={styles.actions}>
                             <TouchableOpacity
                                 onPress={() => updateAlarmDate(alarm.id)}
-                                style={styles.refreshButton}
+                                style={[
+                                    styles.refreshButton,
+                                    { backgroundColor: progressColor },
+                                ]}
                             >
                                 <View style={styles.refreshButtonContent}>
                                     <Text style={styles.refreshButtonText}>갱신</Text>
@@ -213,7 +216,6 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
     },
     refreshButton: {
-        backgroundColor: '#4caf50',
         paddingVertical: 4,
         paddingHorizontal: 12,
         borderRadius: 8,

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -107,8 +107,8 @@ export default function HomeScreen() {
             >
                 <Text style={{ fontSize: 24, fontWeight: 'bold' }}>내 알람</Text>
                 <Image
-                    source={require('../assets/alarm.png')}
-                    style={{ width: 28, height: 28, marginLeft: 8 }}
+                    source={require('../assets/alarm_smile.png')}
+                    style={{ width: 40, height: 40, marginLeft: 8 }}
                 />
             </View>
 


### PR DESCRIPTION
## Summary
- tie Renew button background to its progress bar color
- swap My Alarm header emoji for larger `alarm_smile`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68988b47499c832e88b80b1b10424f9a