### PR TITLE
style: refresh to modern iOS design

### DIFF
--- a/components/AddAlarmModal.tsx
+++ b/components/AddAlarmModal.tsx
@@ -158,13 +158,13 @@ const styles = StyleSheet.create({
     },
     input: {
         borderWidth: 1,
-        borderColor: '#ccc',
+        borderColor: '#E5E5EA',
         borderRadius: 8,
         padding: 12,
         marginTop: 8,
     },
     error: {
-        color: 'red',
+        color: '#FF3B30',
         marginTop: 4,
         fontSize: 12,
     },
@@ -181,13 +181,13 @@ const styles = StyleSheet.create({
         marginHorizontal: 4,
     },
     cancelButton: {
-        backgroundColor: '#a5d6a7',
+        backgroundColor: '#8E8E93',
     },
     submitButton: {
-        backgroundColor: '#4caf50',
+        backgroundColor: '#007AFF',
     },
     buttonDisabled: {
-        backgroundColor: '#c8e6c9',
+        backgroundColor: '#A5A5A5',
     },
     buttonText: {
         color: '#fff',

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -51,7 +51,8 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     const swipeableRef = useRef<Swipeable | null>(null)
 
     const isDue = remainingDays === 0
-    const progressColor = isDue ? '#FFD700' : '#4caf50'
+    const progressColor = isDue ? '#FFCC00' : '#34C759'
+    const refreshTextColor = isDue ? '#000' : '#fff'
 
     const ACTION_WIDTH = 80
     const TOTAL_WIDTH = ACTION_WIDTH * 2
@@ -151,7 +152,14 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                                 ]}
                             >
                                 <View style={styles.refreshButtonContent}>
-                                    <Text style={styles.refreshButtonText}>갱신</Text>
+                                    <Text
+                                        style={[
+                                            styles.refreshButtonText,
+                                            { color: refreshTextColor },
+                                        ]}
+                                    >
+                                        갱신
+                                    </Text>
                                     {isDue && <View style={styles.redDot} />}
                                 </View>
                             </TouchableOpacity>
@@ -165,7 +173,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                             borderRadius={7}
                             color={progressColor}
                             borderColor={progressColor}
-                            unfilledColor="#e0f2f1"
+                            unfilledColor="#E5E5EA"
                             style={styles.progress}
                         />
                         {isDue && (
@@ -228,7 +236,7 @@ const styles = StyleSheet.create({
         width: 6,
         height: 6,
         borderRadius: 3,
-        backgroundColor: '#f44336',
+        backgroundColor: '#FF3B30',
         marginLeft: 4,
     },
     refreshButtonText: {
@@ -258,7 +266,7 @@ const styles = StyleSheet.create({
     },
     subText: {
         fontSize: 12,
-        color: '#888',
+        color: '#8E8E93',
     },
     actionsContainer: {
         height: '100%',
@@ -274,10 +282,10 @@ const styles = StyleSheet.create({
         alignItems: 'center',
     },
     editAction: {
-        backgroundColor: '#81C784',
+        backgroundColor: '#007AFF',
     },
     deleteAction: {
-        backgroundColor: '#388E3C',
+        backgroundColor: '#FF3B30',
     },
     actionButton: {
         flex: 1,

--- a/components/EditAlarmModal.tsx
+++ b/components/EditAlarmModal.tsx
@@ -149,7 +149,7 @@ export default function EditAlarmModal({
                                                 setShowPicker(false)
                                             }}
                                         >
-                                            <Text>확인</Text>
+                                            <Text style={styles.pickerConfirmText}>확인</Text>
                                         </TouchableOpacity>
                                     </View>
                                 </View>
@@ -224,13 +224,13 @@ const styles = StyleSheet.create({
     },
     input: {
         borderWidth: 1,
-        borderColor: '#ccc',
+        borderColor: '#E5E5EA',
         borderRadius: 8,
         padding: 12,
         marginTop: 8,
     },
     error: {
-        color: 'red',
+        color: '#FF3B30',
         marginTop: 4,
         fontSize: 12,
     },
@@ -247,13 +247,13 @@ const styles = StyleSheet.create({
         marginHorizontal: 4,
     },
     cancelButton: {
-        backgroundColor: '#a5d6a7',
+        backgroundColor: '#8E8E93',
     },
     submitButton: {
-        backgroundColor: '#4caf50',
+        backgroundColor: '#007AFF',
     },
     buttonDisabled: {
-        backgroundColor: '#c8e6c9',
+        backgroundColor: '#A5A5A5',
     },
     buttonText: {
         color: '#fff',
@@ -288,10 +288,13 @@ const styles = StyleSheet.create({
         borderRadius: 4,
     },
     pickerCancel: {
-        backgroundColor: '#eee',
+        backgroundColor: '#F2F2F7',
     },
     pickerConfirm: {
-        backgroundColor: '#ddd',
+        backgroundColor: '#007AFF',
+    },
+    pickerConfirmText: {
+        color: '#fff',
     },
 })
 

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -96,7 +96,7 @@ export default function HomeScreen() {
 
     return (
         <SafeAreaView
-            style={{ flex: 1, backgroundColor: '#f0fff4', paddingTop: 24 }}
+            style={{ flex: 1, backgroundColor: '#F2F2F7', paddingTop: 24 }}
         >
             <View
                 style={{
@@ -105,7 +105,11 @@ export default function HomeScreen() {
                     marginHorizontal: 24,
                 }}
             >
-                <Text style={{ fontSize: 24, fontWeight: 'bold' }}>내 알람</Text>
+                <Text
+                    style={{ fontSize: 24, fontWeight: 'bold', color: '#1C1C1E' }}
+                >
+                    내 알람
+                </Text>
                 <Image
                     source={require('../assets/alarm_smile.png')}
                     style={{ width: 40, height: 40, marginLeft: 8 }}
@@ -132,7 +136,7 @@ export default function HomeScreen() {
                             width: 64,
                             height: 64,
                             borderRadius: 32,
-                            backgroundColor: '#4caf50',
+                            backgroundColor: '#007AFF',
                             justifyContent: 'center',
                             alignItems: 'center',
                             shadowColor: '#000',


### PR DESCRIPTION
## Summary
- Refine alarm list cards and actions with iOS-inspired greens, yellows, and reds
- Modernize add/edit modals with system blue accents and subtle gray backgrounds
- Update home screen with neutral background and blue floating add button

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b62229ff8832e9536aa9dcb4a4d9c