### PR TITLE
refactor: simplify alarm list borders and layout

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -66,6 +66,7 @@ const styles = StyleSheet.create({
     container: {
         paddingTop: 16,
         paddingBottom: 32,
+        paddingHorizontal: 24,
     },
 })
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -192,10 +192,10 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 const styles = StyleSheet.create({
     wrapper: {
         marginVertical: 4,
-        borderRadius: 16,
-        overflow: 'hidden',
         backgroundColor: '#fff',
-        borderWidth: 2,
+        borderTopWidth: 1,
+        borderBottomWidth: 1,
+        borderColor: '#cccccc',
     },
     container: {
         backgroundColor: '#fff',
@@ -263,8 +263,6 @@ const styles = StyleSheet.create({
     actionsContainer: {
         height: '100%',
         overflow: 'hidden',
-        borderTopRightRadius: 16,
-        borderBottomRightRadius: 16,
     },
     action: {
         position: 'absolute',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -96,7 +96,7 @@ export default function HomeScreen() {
 
     return (
         <SafeAreaView
-            style={{ flex: 1, backgroundColor: '#f0fff4', paddingTop: 24 }}
+            style={{ flex: 1, backgroundColor: '#ffffff', paddingTop: 24 }}
         >
             <View
                 style={{


### PR DESCRIPTION
## Summary
- use white background across home screen
- add horizontal padding to alarm list
- switch alarm rows to subtle top and bottom gray borders

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689bdf9e8c38832e928a66b8e8c9ec68