### PR TITLE
style: modernize alarm list appearance

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -66,6 +66,8 @@ const styles = StyleSheet.create({
     container: {
         paddingTop: 16,
         paddingBottom: 32,
+        paddingHorizontal: 24,
+        backgroundColor: '#fff',
     },
 })
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -124,7 +124,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     }
 
     return (
-        <View style={[styles.wrapper, { borderColor: progressColor }]}>
+        <View style={styles.wrapper}>
             <Swipeable
                 ref={swipeableRef}
                 renderRightActions={renderRightActions}
@@ -192,10 +192,13 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 const styles = StyleSheet.create({
     wrapper: {
         marginVertical: 4,
-        borderRadius: 16,
         overflow: 'hidden',
         backgroundColor: '#fff',
-        borderWidth: 2,
+        borderTopWidth: 1,
+        borderBottomWidth: 1,
+        borderLeftWidth: 0,
+        borderRightWidth: 0,
+        borderColor: '#ccc',
     },
     container: {
         backgroundColor: '#fff',
@@ -263,8 +266,6 @@ const styles = StyleSheet.create({
     actionsContainer: {
         height: '100%',
         overflow: 'hidden',
-        borderTopRightRadius: 16,
-        borderBottomRightRadius: 16,
     },
     action: {
         position: 'absolute',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -96,7 +96,7 @@ export default function HomeScreen() {
 
     return (
         <SafeAreaView
-            style={{ flex: 1, backgroundColor: '#f0fff4', paddingTop: 24 }}
+            style={{ flex: 1, backgroundColor: '#fff', paddingTop: 24 }}
         >
             <View
                 style={{


### PR DESCRIPTION
## Summary
- restyle alarm rows with subtle grey top and bottom borders
- add horizontal padding and white background to alarm list
- unify home screen background to white for consistent look

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689bdf9e8c38832e928a66b8e8c9ec68