### PR TITLE
style: refresh alarm list spacing and colors

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ const Stack = createNativeStackNavigator<RootStackParamList>()
 
 export default function App() {
   return (
-      <GestureHandlerRootView style={{ flex: 1 }}>
+      <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#fff' }}>
         <NavigationContainer>
           <Stack.Navigator>
             <Stack.Screen

--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -66,6 +66,7 @@ const styles = StyleSheet.create({
     container: {
         paddingTop: 16,
         paddingBottom: 32,
+        paddingHorizontal: 24,
     },
 })
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -52,6 +52,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 
     const isDue = remainingDays === 0
     const progressColor = isDue ? '#FFD700' : '#4caf50'
+    const backgroundColor = isDue ? '#fffde7' : '#f0fff4'
 
     const ACTION_WIDTH = 80
     const TOTAL_WIDTH = ACTION_WIDTH * 2
@@ -124,7 +125,12 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     }
 
     return (
-        <View style={[styles.wrapper, { borderColor: progressColor }]}>
+        <View
+            style={[
+                styles.wrapper,
+                { borderColor: progressColor, backgroundColor },
+            ]}
+        >
             <Swipeable
                 ref={swipeableRef}
                 renderRightActions={renderRightActions}
@@ -133,7 +139,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                 rightThreshold={40}
                 useNativeAnimations={false}
             >
-                <View style={styles.container}>
+                <View style={[styles.container, { backgroundColor }]}>
                     <View style={styles.header}>
                         <Text
                             style={styles.title}
@@ -191,14 +197,12 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 
 const styles = StyleSheet.create({
     wrapper: {
-        marginVertical: 4,
+        marginVertical: 8,
         borderRadius: 16,
         overflow: 'hidden',
-        backgroundColor: '#fff',
         borderWidth: 2,
     },
     container: {
-        backgroundColor: '#fff',
         padding: 12,
     },
     header: {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -96,7 +96,7 @@ export default function HomeScreen() {
 
     return (
         <SafeAreaView
-            style={{ flex: 1, backgroundColor: '#f0fff4', paddingTop: 24 }}
+            style={{ flex: 1, backgroundColor: '#fff', paddingTop: 24 }}
         >
             <View
                 style={{


### PR DESCRIPTION
## Summary
- add horizontal padding around alarm list for better spacing
- tint alarm cards light green or yellow based on progress and add vertical margin
- set global app background to white

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689be3c8c978832eb5d4281b664f47f1