### PR TITLE
Lighten alarm list cards and tighten spacing

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -66,7 +66,8 @@ const styles = StyleSheet.create({
     container: {
         paddingTop: 16,
         paddingBottom: 32,
-        paddingHorizontal: 24,
+        // Bring list items a bit closer to the screen edges
+        paddingHorizontal: 16,
     },
 })
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -52,7 +52,8 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 
     const isDue = remainingDays === 0
     const progressColor = isDue ? '#FFD700' : '#4caf50'
-    const backgroundColor = isDue ? '#fffde7' : '#f0fff4'
+    // Use a lighter fill so the cards feel less heavy while keeping text readable
+    const backgroundColor = isDue ? '#fffef4' : '#f7fff9'
 
     const ACTION_WIDTH = 80
     const TOTAL_WIDTH = ACTION_WIDTH * 2
@@ -171,7 +172,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                             borderRadius={7}
                             color={progressColor}
                             borderColor={progressColor}
-                            unfilledColor="#e0f2f1"
+                            unfilledColor="#f0f5f4"
                             style={styles.progress}
                         />
                         {isDue && (
@@ -265,10 +266,16 @@ const styles = StyleSheet.create({
         color: '#888',
     },
     actionsContainer: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        right: 0,
         height: '100%',
         overflow: 'hidden',
         borderTopRightRadius: 16,
         borderBottomRightRadius: 16,
+        // Fill behind actions so no background peeks through when swiping
+        backgroundColor: '#388E3C',
     },
     action: {
         position: 'absolute',

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -102,7 +102,8 @@ export default function HomeScreen() {
                 style={{
                     flexDirection: 'row',
                     alignItems: 'center',
-                    marginHorizontal: 24,
+                    // Match tighter list spacing
+                    marginHorizontal: 16,
                 }}
             >
                 <Text style={{ fontSize: 24, fontWeight: 'bold' }}>내 알람</Text>


### PR DESCRIPTION
## Summary
- soften card fill colors for alarms and align progress bar background
- reduce list and header horizontal padding for tighter layout
- anchor swipe delete pane to card border to remove background gap

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689be645b5c4832e9b8ca7a6455b8acc