### PR TITLE
feat: refine list cards and eliminate swipe gap

### DIFF
--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
     container: {
         paddingTop: 16,
         paddingBottom: 32,
-        paddingHorizontal: 24,
+        paddingHorizontal: 16,
     },
 })
 

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -52,7 +52,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
 
     const isDue = remainingDays === 0
     const progressColor = isDue ? '#FFD700' : '#4caf50'
-    const backgroundColor = isDue ? '#fffde7' : '#f0fff4'
+    const backgroundColor = isDue ? '#fffef2' : '#f7fffa'
 
     const ACTION_WIDTH = 80
     const TOTAL_WIDTH = ACTION_WIDTH * 2
@@ -203,7 +203,7 @@ const styles = StyleSheet.create({
         borderWidth: 2,
     },
     container: {
-        padding: 12,
+        padding: 10,
     },
     header: {
         flexDirection: 'row',
@@ -265,10 +265,15 @@ const styles = StyleSheet.create({
         color: '#888',
     },
     actionsContainer: {
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        right: 0,
         height: '100%',
         overflow: 'hidden',
         borderTopRightRadius: 16,
         borderBottomRightRadius: 16,
+        backgroundColor: '#388E3C',
     },
     action: {
         position: 'absolute',


### PR DESCRIPTION
## Summary
- lighten alarm card backgrounds for a softer look
- reduce list padding for tighter horizontal spacing
- ensure swipe delete pane fills edge-to-edge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689be645b5c4832e9b8ca7a6455b8acc