### PR TITLE
Unify overdue alarm styling and refine swipe actions

### DIFF
--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -1,12 +1,5 @@
 import React, { useRef } from 'react'
-import {
-    View,
-    Text,
-    TouchableOpacity,
-    StyleSheet,
-    Animated,
-    Image,
-} from 'react-native'
+import { View, Text, TouchableOpacity, StyleSheet, Image } from 'react-native'
 import { Swipeable } from 'react-native-gesture-handler'
 import * as Progress from 'react-native-progress'
 import { Alarm } from '../types/Alarm'
@@ -51,84 +44,35 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
     const swipeableRef = useRef<Swipeable | null>(null)
 
     const isDue = remainingDays === 0
-    const progressColor = isDue ? '#FFD700' : '#4caf50'
-    const backgroundColor = isDue ? '#fffde7' : '#f0fff4'
+    const progressColor = '#4caf50'
+    const backgroundColor = '#f0fff4'
+    const borderColor = '#A5D6A7'
 
-    const ACTION_WIDTH = 80
-    const TOTAL_WIDTH = ACTION_WIDTH * 2
+    const ACTION_WIDTH = 60
 
-    const renderRightActions = (
-        swipeProgress: Animated.AnimatedInterpolation<number>,
-        dragX: Animated.AnimatedInterpolation<number>
-    ) => {
-        const translateX = dragX.interpolate({
-            inputRange: [-TOTAL_WIDTH, 0],
-            outputRange: [0, TOTAL_WIDTH],
-            extrapolate: 'clamp',
-        })
-
-        const actionWidth = swipeProgress.interpolate({
-            inputRange: [0, 1],
-            outputRange: [0, ACTION_WIDTH],
-            extrapolate: 'clamp',
-        })
-
-        return (
-            <Animated.View
-                style={[
-                    styles.actionsContainer,
-                    {
-                        width: TOTAL_WIDTH,
-                        transform: [{ translateX }],
-                    },
-                ]}
+    const renderRightActions = () => (
+        <View style={[styles.actionsContainer, { width: ACTION_WIDTH * 2 }]}>
+            <TouchableOpacity
+                ref={editRef}
+                onPress={() => onEdit(alarm, editRef.current, swipeableRef.current)}
+                style={[styles.action, styles.editAction, { width: ACTION_WIDTH }]}
             >
-                <Animated.View
-                    style={[
-                        styles.action,
-                        styles.editAction,
-                        {
-                            width: actionWidth,
-                            left: 0,
-                        },
-                    ]}
-                >
-                    <TouchableOpacity
-                        ref={editRef}
-                        onPress={() =>
-                            onEdit(alarm, editRef.current, swipeableRef.current)
-                        }
-                        style={styles.actionButton}
-                    >
-                        <Text style={styles.actionLabel}>수정</Text>
-                    </TouchableOpacity>
-                </Animated.View>
-                <Animated.View
-                    style={[
-                        styles.action,
-                        styles.deleteAction,
-                        {
-                            width: actionWidth,
-                            left: actionWidth,
-                        },
-                    ]}
-                >
-                    <TouchableOpacity
-                        onPress={() => deleteAlarm(alarm.id)}
-                        style={styles.actionButton}
-                    >
-                        <Text style={styles.actionLabel}>삭제</Text>
-                    </TouchableOpacity>
-                </Animated.View>
-            </Animated.View>
-        )
-    }
+                <Text style={styles.actionLabel}>수정</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+                onPress={() => deleteAlarm(alarm.id)}
+                style={[styles.action, styles.deleteAction, { width: ACTION_WIDTH }]}
+            >
+                <Text style={styles.actionLabel}>삭제</Text>
+            </TouchableOpacity>
+        </View>
+    )
 
     return (
         <View
             style={[
                 styles.wrapper,
-                { borderColor: progressColor, backgroundColor },
+                { borderColor, backgroundColor },
             ]}
         >
             <Swipeable
@@ -269,11 +213,9 @@ const styles = StyleSheet.create({
         overflow: 'hidden',
         borderTopRightRadius: 16,
         borderBottomRightRadius: 16,
+        flexDirection: 'row',
     },
     action: {
-        position: 'absolute',
-        top: 0,
-        bottom: 0,
         justifyContent: 'center',
         alignItems: 'center',
     },
@@ -282,11 +224,6 @@ const styles = StyleSheet.create({
     },
     deleteAction: {
         backgroundColor: '#388E3C',
-    },
-    actionButton: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
     },
     actionLabel: {
         color: '#ffffff',


### PR DESCRIPTION
## Summary
- use consistent colors and background for alarms at day 0, with a lighter border
- display swipe actions horizontally with narrower width

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c89644214832eb56f9b4534671524