### PR TITLE
feat: replace start date input with calendar picker

### DIFF
--- a/components/DatePickerField.tsx
+++ b/components/DatePickerField.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react'
+import {
+    Pressable,
+    Text,
+    Modal,
+    View,
+    TouchableOpacity,
+    StyleSheet,
+    Platform,
+    StyleProp,
+    ViewStyle,
+} from 'react-native'
+import DateTimePicker from '@react-native-community/datetimepicker'
+
+interface Props {
+    value: Date
+    onChange: (date: Date) => void
+    style?: StyleProp<ViewStyle>
+}
+
+export default function DatePickerField({ value, onChange, style }: Props) {
+    const [visible, setVisible] = useState(false)
+    const [temp, setTemp] = useState(value)
+
+    const open = () => {
+        setTemp(value)
+        setVisible(true)
+    }
+
+    const handleChange = (_: any, selected?: Date) => {
+        if (selected) setTemp(selected)
+    }
+
+    const confirm = () => {
+        onChange(temp)
+        setVisible(false)
+    }
+
+    return (
+        <>
+            <Pressable onPress={open} style={style}>
+                <Text>{value.toLocaleDateString()}</Text>
+            </Pressable>
+            {visible && (
+                <Modal transparent animationType="fade">
+                    <View style={styles.overlay}>
+                        <View style={styles.content}>
+                            <DateTimePicker
+                                value={temp}
+                                mode="date"
+                                display={Platform.OS === 'ios' ? 'spinner' : 'calendar'}
+                                onChange={handleChange}
+                                style={styles.picker}
+                            />
+                            <View style={styles.buttons}>
+                                <TouchableOpacity
+                                    style={[styles.button, styles.cancel]}
+                                    onPress={() => setVisible(false)}
+                                >
+                                    <Text>취소</Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                    style={[styles.button, styles.confirm]}
+                                    onPress={confirm}
+                                >
+                                    <Text>확인</Text>
+                                </TouchableOpacity>
+                            </View>
+                        </View>
+                    </View>
+                </Modal>
+            )}
+        </>
+    )
+}
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'rgba(0,0,0,0.5)',
+    },
+    content: {
+        backgroundColor: '#fff',
+        padding: 16,
+        borderRadius: 8,
+        alignItems: 'center',
+    },
+    picker: {
+        backgroundColor: '#fff',
+    },
+    buttons: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        width: '100%',
+        marginTop: 12,
+    },
+    button: {
+        flex: 1,
+        alignItems: 'center',
+        padding: 8,
+        marginHorizontal: 4,
+        borderRadius: 4,
+    },
+    cancel: {
+        backgroundColor: '#eee',
+    },
+    confirm: {
+        backgroundColor: '#ddd',
+    },
+})

--- a/components/DatePickerField.tsx
+++ b/components/DatePickerField.tsx
@@ -22,6 +22,11 @@ export default function DatePickerField({ value, onChange, style }: Props) {
     const [visible, setVisible] = useState(false)
     const [temp, setTemp] = useState(value)
 
+    const display =
+        Platform.OS === 'ios'
+            ? (parseInt(String(Platform.Version), 10) >= 14 ? 'inline' : 'spinner')
+            : 'calendar'
+
     const open = () => {
         setTemp(value)
         setVisible(true)
@@ -48,7 +53,7 @@ export default function DatePickerField({ value, onChange, style }: Props) {
                             <DateTimePicker
                                 value={temp}
                                 mode="date"
-                                display={Platform.OS === 'ios' ? 'spinner' : 'calendar'}
+                                display={display}
                                 onChange={handleChange}
                                 style={styles.picker}
                             />

--- a/components/EditAlarmModal.tsx
+++ b/components/EditAlarmModal.tsx
@@ -9,10 +9,9 @@ import {
     ActivityIndicator,
     KeyboardAvoidingView,
     Platform,
-    Pressable,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import DateTimePicker from '@react-native-community/datetimepicker'
+import DatePickerField from './DatePickerField'
 import { Alarm } from '../types/Alarm'
 
 interface Props {
@@ -36,8 +35,6 @@ export default function EditAlarmModal({
     const [name, setName] = useState('')
     const [interval, setInterval] = useState('')
     const [startDate, setStartDate] = useState(new Date())
-    const [tempDate, setTempDate] = useState(new Date())
-    const [showPicker, setShowPicker] = useState(false)
     const [nameError, setNameError] = useState('')
     const [intervalError, setIntervalError] = useState('')
     const [saving, setSaving] = useState(false)
@@ -48,7 +45,6 @@ export default function EditAlarmModal({
             setInterval(String(alarm.interval))
             const d = new Date(alarm.createdAt)
             setStartDate(d)
-            setTempDate(d)
             setNameError('')
             setIntervalError('')
         }
@@ -84,15 +80,6 @@ export default function EditAlarmModal({
         onClose()
     }
 
-    const openPicker = () => {
-        setTempDate(startDate)
-        setShowPicker(true)
-    }
-
-    const onChangeTempDate = (_: any, selected?: Date) => {
-        if (selected) setTempDate(selected)
-    }
-
     return (
         <Modal
             visible={visible}
@@ -117,45 +104,11 @@ export default function EditAlarmModal({
                     {nameError ? <Text style={styles.error}>{nameError}</Text> : null}
 
                     <Text style={styles.label}>시작일</Text>
-                    <Pressable onPress={openPicker} style={styles.input}>
-                        <Text>{startDate.toISOString().slice(0, 10)}</Text>
-                    </Pressable>
-                    {showPicker && (
-                        <Modal transparent animationType="fade">
-                            <View style={styles.modalOverlay}>
-                                <View style={styles.modalContent}>
-                                    <DateTimePicker
-                                        value={tempDate}
-                                        mode="date"
-                                        display={
-                                            Platform.OS === 'ios'
-                                                ? 'spinner'
-                                                : 'calendar'
-                                        }
-                                        onChange={onChangeTempDate}
-                                        style={styles.modalPicker}
-                                    />
-                                    <View style={styles.modalButtons}>
-                                        <TouchableOpacity
-                                            style={[styles.pickerButton, styles.pickerCancel]}
-                                            onPress={() => setShowPicker(false)}
-                                        >
-                                            <Text>취소</Text>
-                                        </TouchableOpacity>
-                                        <TouchableOpacity
-                                            style={[styles.pickerButton, styles.pickerConfirm]}
-                                            onPress={() => {
-                                                setStartDate(tempDate)
-                                                setShowPicker(false)
-                                            }}
-                                        >
-                                            <Text>확인</Text>
-                                        </TouchableOpacity>
-                                    </View>
-                                </View>
-                            </View>
-                        </Modal>
-                    )}
+                    <DatePickerField
+                        value={startDate}
+                        onChange={setStartDate}
+                        style={styles.input}
+                    />
 
                     <Text style={styles.label}>주기 (일)</Text>
                     <TextInput
@@ -258,40 +211,6 @@ const styles = StyleSheet.create({
     buttonText: {
         color: '#fff',
         fontWeight: 'bold',
-    },
-    modalOverlay: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: 'rgba(0,0,0,0.5)',
-    },
-    modalContent: {
-        backgroundColor: '#fff',
-        padding: 16,
-        borderRadius: 8,
-        alignItems: 'center',
-    },
-    modalPicker: {
-        backgroundColor: '#fff',
-    },
-    modalButtons: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        width: '100%',
-        marginTop: 12,
-    },
-    pickerButton: {
-        flex: 1,
-        alignItems: 'center',
-        padding: 8,
-        marginHorizontal: 4,
-        borderRadius: 4,
-    },
-    pickerCancel: {
-        backgroundColor: '#eee',
-    },
-    pickerConfirm: {
-        backgroundColor: '#ddd',
     },
 })
 


### PR DESCRIPTION
## Summary
- add reusable DatePickerField component that pops up calendar UI
- integrate DatePickerField into EditAlarmModal for start date selection

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c978d614c832e87ede199d7994063