### PR TITLE
feat: apply Jua font to alarm titles

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,26 +1,35 @@
-import {StyleSheet} from 'react-native';
-import {NavigationContainer} from '@react-navigation/native'
-import {createNativeStackNavigator} from '@react-navigation/native-stack'
+import { StyleSheet } from 'react-native'
+import { NavigationContainer } from '@react-navigation/native'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { useFonts } from 'expo-font'
 import { RootStackParamList } from './types/navigation'
 import HomeScreen from './screens/HomeScreen'
 
 const Stack = createNativeStackNavigator<RootStackParamList>()
 
 export default function App() {
+  const [fontsLoaded] = useFonts({
+    'Jua-Regular': require('./assets/fonts/Jua-Regular.ttf'),
+  })
+
+  if (!fontsLoaded) {
+    return null
+  }
+
   return (
-      <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#fff' }}>
-        <NavigationContainer>
-          <Stack.Navigator>
-            <Stack.Screen
-              name="Home"
-              component={HomeScreen}
-              options={{ headerShown: false }}
-            />
-          </Stack.Navigator>
-        </NavigationContainer>
-      </GestureHandlerRootView>
-  );
+    <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#fff' }}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="Home"
+            component={HomeScreen}
+            options={{ headerShown: false }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
+  )
 }
 
 const styles = StyleSheet.create({

--- a/components/AddAlarmModal.tsx
+++ b/components/AddAlarmModal.tsx
@@ -157,6 +157,7 @@ const styles = StyleSheet.create({
         marginTop: 12,
     },
     input: {
+        fontFamily: 'Jua-Regular',
         borderWidth: 1,
         borderColor: '#ccc',
         borderRadius: 8,

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -274,6 +274,7 @@ const styles = StyleSheet.create({
         flex: 1,
         fontSize: 20,
         fontWeight: 'bold',
+        fontFamily: 'Jua-Regular',
         marginRight: 8,
         flexShrink: 1,
     },

--- a/components/EditAlarmModal.tsx
+++ b/components/EditAlarmModal.tsx
@@ -176,6 +176,7 @@ const styles = StyleSheet.create({
         marginTop: 12,
     },
     input: {
+        fontFamily: 'Jua-Regular',
         borderWidth: 1,
         borderColor: '#ccc',
         borderRadius: 8,


### PR DESCRIPTION
## Summary
- load Jua-Regular font at app startup
- render alarm titles and title inputs with Jua-Regular typeface

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689caa26e8c4832e8472b6591e22c603