### PR TITLE
feat: apply Jua font to alarm titles

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,26 +1,35 @@
-import {StyleSheet} from 'react-native';
-import {NavigationContainer} from '@react-navigation/native'
-import {createNativeStackNavigator} from '@react-navigation/native-stack'
+import { StyleSheet } from 'react-native'
+import { NavigationContainer } from '@react-navigation/native'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { useFonts } from 'expo-font'
 import { RootStackParamList } from './types/navigation'
 import HomeScreen from './screens/HomeScreen'
 
 const Stack = createNativeStackNavigator<RootStackParamList>()
 
 export default function App() {
+  const [fontsLoaded] = useFonts({
+    'Jua-Regular': require('./assets/fonts/Jua-Regular.ttf'),
+  })
+
+  if (!fontsLoaded) {
+    return null
+  }
+
   return (
-      <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#fff' }}>
-        <NavigationContainer>
-          <Stack.Navigator>
-            <Stack.Screen
-              name="Home"
-              component={HomeScreen}
-              options={{ headerShown: false }}
-            />
-          </Stack.Navigator>
-        </NavigationContainer>
-      </GestureHandlerRootView>
-  );
+    <GestureHandlerRootView style={{ flex: 1, backgroundColor: '#fff' }}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="Home"
+            component={HomeScreen}
+            options={{ headerShown: false }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
+  )
 }
 
 const styles = StyleSheet.create({

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -276,6 +276,7 @@ const styles = StyleSheet.create({
         fontWeight: 'bold',
         marginRight: 8,
         flexShrink: 1,
+        fontFamily: 'Jua-Regular',
     },
     actions: {
         flexDirection: 'row',


### PR DESCRIPTION
## Summary
- load Jua-Regular font using expo-font
- render alarm titles with the new Jua-Regular font

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689caa26e8c4832e8472b6591e22c603