### PR TITLE
Add locale-based system text translation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,11 +17,12 @@ export default function App() {
     return null
   }
 
-  if (Text.defaultProps == null) {
-    Text.defaultProps = {}
+  const TextComponent = Text as any
+  if (TextComponent.defaultProps == null) {
+    TextComponent.defaultProps = {}
   }
-  Text.defaultProps.style = {
-    ...(Text.defaultProps.style || {}),
+  TextComponent.defaultProps.style = {
+    ...(TextComponent.defaultProps.style || {}),
     fontFamily: 'Jua-Regular',
   }
 

--- a/components/AddAlarmModal.tsx
+++ b/components/AddAlarmModal.tsx
@@ -11,6 +11,7 @@ import {
     Platform,
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
+import { t } from '../i18n'
 
 interface Props {
     visible: boolean
@@ -37,7 +38,7 @@ export default function AddAlarmModal({ visible, onClose, onSubmit }: Props) {
     const onChangeName = (text: string) => {
         setName(text)
         const trimmed = text.trim()
-        setNameError(trimmed ? '' : '알람 제목을 입력해 주세요.')
+        setNameError(trimmed ? '' : t('nameError'))
     }
 
     const onChangeInterval = (text: string) => {
@@ -45,7 +46,7 @@ export default function AddAlarmModal({ visible, onClose, onSubmit }: Props) {
         const parsed = parseInt(text, 10)
         setIntervalError(
             text.trim().length === 0 || isNaN(parsed) || parsed < 1
-                ? '주기는 1 이상의 숫자여야 합니다.'
+                ? t('intervalError')
                 : ''
         )
     }
@@ -76,27 +77,27 @@ export default function AddAlarmModal({ visible, onClose, onSubmit }: Props) {
                 style={styles.overlay}
             >
                 <SafeAreaView style={styles.container}>
-                    <Text style={styles.title}>알람 등록</Text>
-                    <Text style={styles.label}>알람 제목</Text>
+                    <Text style={styles.title}>{t('addAlarm')}</Text>
+                    <Text style={styles.label}>{t('alarmTitle')}</Text>
                     <TextInput
                         style={styles.input}
                         value={name}
                         onChangeText={onChangeName}
                         maxLength={50}
-                        placeholder="예: 칫솔 교체"
+                        placeholder={t('alarmTitlePlaceholder')}
                         autoFocus
                     />
                     {nameError ? (
                         <Text style={styles.error}>{nameError}</Text>
                     ) : null}
 
-                    <Text style={styles.label}>주기 (일)</Text>
+                    <Text style={styles.label}>{t('interval')}</Text>
                     <TextInput
                         style={styles.input}
                         value={interval}
                         onChangeText={onChangeInterval}
                         keyboardType="number-pad"
-                        placeholder="예: 30"
+                        placeholder={t('intervalPlaceholder')}
                     />
                     {intervalError ? (
                         <Text style={styles.error}>{intervalError}</Text>
@@ -108,7 +109,7 @@ export default function AddAlarmModal({ visible, onClose, onSubmit }: Props) {
                             onPress={onClose}
                             disabled={saving}
                         >
-                            <Text style={styles.buttonText}>취소</Text>
+                            <Text style={styles.buttonText}>{t('cancel')}</Text>
                         </TouchableOpacity>
                         <TouchableOpacity
                             style={[
@@ -122,7 +123,7 @@ export default function AddAlarmModal({ visible, onClose, onSubmit }: Props) {
                             {saving ? (
                                 <ActivityIndicator color="#fff" />
                             ) : (
-                                <Text style={styles.buttonText}>등록</Text>
+                                <Text style={styles.buttonText}>{t('add')}</Text>
                             )}
                         </TouchableOpacity>
                     </View>

--- a/components/AlarmRow.tsx
+++ b/components/AlarmRow.tsx
@@ -9,6 +9,7 @@ import {
 import { Swipeable } from 'react-native-gesture-handler'
 import * as Progress from 'react-native-progress'
 import { Alarm } from '../types/Alarm'
+import { t, dateLocale } from '../i18n'
 
 type Props = {
     alarm: Alarm
@@ -35,10 +36,11 @@ const calculateProgress = (createdAt: string, interval: number) => {
 
 const formatDate = (dateString: string) => {
     const date = new Date(dateString)
-    const year = date.getFullYear()
-    const month = String(date.getMonth() + 1).padStart(2, '0')
-    const day = String(date.getDate()).padStart(2, '0')
-    return `${year}/${month}/${day}`
+    return new Intl.DateTimeFormat(dateLocale, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    }).format(date)
 }
 
 const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
@@ -113,13 +115,13 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                 onPress={() => onEdit(alarm, editRef.current, swipeableRef.current)}
                 style={[styles.action, styles.editAction, { width: ACTION_WIDTH }]}
             >
-                <Text style={styles.actionLabel}>수정</Text>
+                <Text style={styles.actionLabel}>{t('edit')}</Text>
             </TouchableOpacity>
             <TouchableOpacity
                 onPress={() => deleteAlarm(alarm.id)}
                 style={[styles.action, styles.deleteAction, { width: ACTION_WIDTH }]}
             >
-                <Text style={styles.actionLabel}>삭제</Text>
+                <Text style={styles.actionLabel}>{t('delete')}</Text>
             </TouchableOpacity>
         </View>
     )
@@ -157,7 +159,7 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                                 ]}
                             >
                                 <View style={styles.refreshButtonContent}>
-                                    <Text style={styles.refreshButtonText}>갱신</Text>
+                                    <Text style={styles.refreshButtonText}>{t('refresh')}</Text>
                                     {isDue && <View style={styles.redDot} />}
                                 </View>
                             </TouchableOpacity>
@@ -244,10 +246,10 @@ const AlarmRow = ({ alarm, deleteAlarm, updateAlarmDate, onEdit }: Props) => {
                     </View>
                     <View style={styles.footer}>
                         <Text style={styles.subText}>
-                            시작일: {formatDate(alarm.createdAt)}
+                            {t('startDateLabel')} {formatDate(alarm.createdAt)}
                         </Text>
                         <Text style={styles.subText}>
-                            남은 일수: {remainingDays}일
+                            {t('remainingDays')} {remainingDays}{t('days')}
                         </Text>
                     </View>
                 </View>

--- a/components/DatePickerField.tsx
+++ b/components/DatePickerField.tsx
@@ -11,13 +11,14 @@ import {
     ViewStyle,
 } from 'react-native'
 import DateTimePicker from '@react-native-community/datetimepicker'
+import { t, dateLocale } from '../i18n'
 
-const formatKoreanDate = (date: Date) => {
-    const year = date.getFullYear()
-    const month = String(date.getMonth() + 1).padStart(2, '0')
-    const day = String(date.getDate()).padStart(2, '0')
-    return `${year}/${month}/${day}`
-}
+const formatDate = (date: Date) =>
+    new Intl.DateTimeFormat(dateLocale, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    }).format(date)
 
 interface Props {
     value: Date
@@ -51,7 +52,7 @@ export default function DatePickerField({ value, onChange, style }: Props) {
     return (
         <>
             <Pressable onPress={open} style={style}>
-                <Text style={styles.dateText}>{formatKoreanDate(value)}</Text>
+                <Text style={styles.dateText}>{formatDate(value)}</Text>
             </Pressable>
             {visible && (
                 <Modal transparent animationType="fade">
@@ -63,20 +64,20 @@ export default function DatePickerField({ value, onChange, style }: Props) {
                                 display={display}
                                 onChange={handleChange}
                                 style={styles.picker}
-                                locale="ko-KR"
+                                locale={dateLocale}
                             />
                             <View style={styles.buttons}>
                                 <TouchableOpacity
                                     style={[styles.button, styles.cancel]}
                                     onPress={() => setVisible(false)}
                                 >
-                                    <Text style={styles.buttonText}>취소</Text>
+                                    <Text style={styles.buttonText}>{t('cancel')}</Text>
                                 </TouchableOpacity>
                                 <TouchableOpacity
                                     style={[styles.button, styles.confirm]}
                                     onPress={confirm}
                                 >
-                                    <Text style={styles.buttonText}>확인</Text>
+                                    <Text style={styles.buttonText}>{t('confirm')}</Text>
                                 </TouchableOpacity>
                             </View>
                         </View>

--- a/components/EditAlarmModal.tsx
+++ b/components/EditAlarmModal.tsx
@@ -13,6 +13,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context'
 import DatePickerField from './DatePickerField'
 import { Alarm } from '../types/Alarm'
+import { t } from '../i18n'
 
 interface Props {
     visible: boolean
@@ -53,7 +54,7 @@ export default function EditAlarmModal({
     const onChangeName = (text: string) => {
         setName(text)
         const trimmed = text.trim()
-        setNameError(trimmed ? '' : '알람 제목을 입력해 주세요.')
+        setNameError(trimmed ? '' : t('nameError'))
     }
 
     const onChangeInterval = (text: string) => {
@@ -61,7 +62,7 @@ export default function EditAlarmModal({
         const parsed = parseInt(text, 10)
         setIntervalError(
             text.trim().length === 0 || isNaN(parsed) || parsed < 1
-                ? '주기는 1 이상의 숫자여야 합니다.'
+                ? t('intervalError')
                 : ''
         )
     }
@@ -92,8 +93,8 @@ export default function EditAlarmModal({
                 style={styles.overlay}
             >
                 <SafeAreaView style={styles.container}>
-                    <Text style={styles.title}>알람 수정</Text>
-                    <Text style={styles.label}>알람 제목</Text>
+                    <Text style={styles.title}>{t('editAlarm')}</Text>
+                    <Text style={styles.label}>{t('alarmTitle')}</Text>
                     <TextInput
                         style={styles.input}
                         value={name}
@@ -103,14 +104,14 @@ export default function EditAlarmModal({
                     />
                     {nameError ? <Text style={styles.error}>{nameError}</Text> : null}
 
-                    <Text style={styles.label}>시작일</Text>
+                    <Text style={styles.label}>{t('startDate')}</Text>
                     <DatePickerField
                         value={startDate}
                         onChange={setStartDate}
                         style={styles.input}
                     />
 
-                    <Text style={styles.label}>주기 (일)</Text>
+                    <Text style={styles.label}>{t('interval')}</Text>
                     <TextInput
                         style={styles.input}
                         value={interval}
@@ -127,7 +128,7 @@ export default function EditAlarmModal({
                             onPress={onClose}
                             disabled={saving}
                         >
-                            <Text style={styles.buttonText}>취소</Text>
+                            <Text style={styles.buttonText}>{t('cancel')}</Text>
                         </TouchableOpacity>
                         <TouchableOpacity
                             style={[
@@ -141,7 +142,7 @@ export default function EditAlarmModal({
                             {saving ? (
                                 <ActivityIndicator color="#fff" />
                             ) : (
-                                <Text style={styles.buttonText}>저장</Text>
+                                <Text style={styles.buttonText}>{t('save')}</Text>
                             )}
                         </TouchableOpacity>
                     </View>

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,54 @@
+const languageTag = Intl.DateTimeFormat().resolvedOptions().locale;
+export const language = languageTag.startsWith('ko') ? 'ko' : 'en';
+export const dateLocale = language === 'ko' ? 'ko-KR' : 'en-US';
+
+const translations: Record<string, Record<string, string>> = {
+  en: {
+    myAlarms: 'My Alarms',
+    addAlarm: 'Add Alarm',
+    alarmTitle: 'Alarm Title',
+    alarmTitlePlaceholder: 'e.g., Replace toothbrush',
+    interval: 'Interval (days)',
+    intervalPlaceholder: 'e.g., 30',
+    cancel: 'Cancel',
+    add: 'Add',
+    editAlarm: 'Edit Alarm',
+    startDate: 'Start Date',
+    save: 'Save',
+    refresh: 'Reset',
+    edit: 'Edit',
+    delete: 'Delete',
+    startDateLabel: 'Start:',
+    remainingDays: 'Remaining days:',
+    days: ' days',
+    confirm: 'Confirm',
+    nameError: 'Please enter alarm title.',
+    intervalError: 'Interval must be a number greater than or equal to 1.',
+  },
+  ko: {
+    myAlarms: '내 알람',
+    addAlarm: '알람 등록',
+    alarmTitle: '알람 제목',
+    alarmTitlePlaceholder: '예: 칫솔 교체',
+    interval: '주기 (일)',
+    intervalPlaceholder: '예: 30',
+    cancel: '취소',
+    add: '등록',
+    editAlarm: '알람 수정',
+    startDate: '시작일',
+    save: '저장',
+    refresh: '갱신',
+    edit: '수정',
+    delete: '삭제',
+    startDateLabel: '시작일:',
+    remainingDays: '남은 일수:',
+    days: '일',
+    confirm: '확인',
+    nameError: '알람 제목을 입력해 주세요.',
+    intervalError: '주기는 1 이상의 숫자여야 합니다.',
+  },
+};
+
+export const t = (key: string): string => {
+  return translations[language][key] || translations.en[key] || key;
+};

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -8,6 +8,7 @@ import { useState, useCallback, useRef } from 'react'
 import AddAlarmModal from '../components/AddAlarmModal'
 import EditAlarmModal from '../components/EditAlarmModal'
 import { Swipeable } from 'react-native-gesture-handler'
+import { t } from '../i18n'
 
 export default function HomeScreen() {
     const [alarms, setAlarms] = useState<Alarm[]>([])
@@ -108,7 +109,7 @@ export default function HomeScreen() {
                 <Text
                     style={{ fontSize: 24, fontWeight: 'bold', fontFamily: 'Jua-Regular' }}
                 >
-                    내 알람
+                    {t('myAlarms')}
                 </Text>
                 <Image
                     source={require('../assets/alarm_smile.png')}


### PR DESCRIPTION
## Summary
- add lightweight i18n helper to switch system text between Korean and English
- localize alarm list, modals, and date picker labels without altering user-entered text
- format dates according to the current locale

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cb6507ea8832ea886883ebcfe5c15