### PR TITLE
feat: show AdMob banner on alarm list

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,8 @@ import { NavigationContainer } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { useFonts } from 'expo-font'
+import { useEffect } from 'react'
+import mobileAds from 'react-native-google-mobile-ads'
 import { RootStackParamList } from './types/navigation'
 import HomeScreen from './screens/HomeScreen'
 
@@ -12,6 +14,10 @@ export default function App() {
   const [fontsLoaded] = useFonts({
     'Jua-Regular': require('./assets/fonts/Jua-Regular.ttf'),
   })
+
+  useEffect(() => {
+    void mobileAds().initialize()
+  }, [])
 
   if (!fontsLoaded) {
     return null

--- a/app.json
+++ b/app.json
@@ -26,7 +26,13 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-font"
+      "expo-font",
+      [
+        "react-native-google-mobile-ads",
+        {
+          "ios_app_id": "ca-app-pub-2229465145229904~3323224724"
+        }
+      ]
     ]
   }
 }

--- a/components/AdBanner.tsx
+++ b/components/AdBanner.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { View } from 'react-native'
+import { BannerAd, BannerAdSize } from 'react-native-google-mobile-ads'
+
+const unitId = 'ca-app-pub-2229465145229904/3161806144'
+
+export default function AdBanner() {
+  return (
+    <View style={{ alignItems: 'center', marginBottom: 16 }}>
+      <BannerAd unitId={unitId} size={BannerAdSize.BANNER} />
+    </View>
+  )
+}

--- a/components/AlarmList.tsx
+++ b/components/AlarmList.tsx
@@ -3,6 +3,7 @@ import { FlatList, StyleSheet } from 'react-native'
 import AlarmRow from './AlarmRow'
 import { Alarm } from '../types/Alarm'
 import { Swipeable } from 'react-native-gesture-handler'
+import AdBanner from './AdBanner'
 
 type Props = {
     alarms: Alarm[]
@@ -57,6 +58,7 @@ const AlarmList = ({
             )}
             contentContainerStyle={styles.container}
             showsVerticalScrollIndicator={false}
+            ListHeaderComponent={<AdBanner />}
             ListFooterComponent={footer}
         />
     )

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "^0.20.0",
-    "expo-font": "~13.3.2"
+    "expo-font": "~13.3.2",
+    "react-native-google-mobile-ads": "^11.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- configure mobile ads plugin with iOS app id
- initialize mobile ads and render banner in alarm list

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-native-google-mobile-ads)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cbcdc432c832eb3b6e03cf86c27ad